### PR TITLE
ci: deploy knot-so-good to GitHub Pages on push to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,45 @@
+name: Deploy knot-so-good to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # master
+        with:
+          toolchain: stable
+          targets: wasm32-unknown-unknown
+
+      - uses: Swatinem/rust-cache@bc2d2e71bd35c5549942babaa51a89c586b981d1 # v2.8.1
+        with:
+          workspaces: examples/knot-so-good
+
+      - uses: cargo-bins/cargo-binstall@bc432b49369a3f25c8c8b19578a82060c18a5dd6 # v1.17.6
+
+      - run: cargo binstall trunk@0.21.4 --no-confirm
+
+      - run: trunk build --release --public-url "/${{ github.event.repository.name }}/"
+        working-directory: examples/knot-so-good
+
+      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
+        with:
+          path: examples/knot-so-good/dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
+        id: deployment


### PR DESCRIPTION
Adds a GitHub Actions workflow that builds the knot-so-good Yew/WASM app with Trunk and deploys it to GitHub Pages. All actions are pinned to full commit SHAs. Trunk is installed via cargo-binstall (pre-built binary) to avoid recompiling it on every run.

https://claude.ai/code/session_019gZp8oEvA8oi3NECRScSpy