### PR TITLE
ci: add Claude PR review and interactive comment workflows

### DIFF
--- a/.github/workflows/claude-interactive.yml
+++ b/.github/workflows/claude-interactive.yml
@@ -1,0 +1,34 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  issues:
+    types: [opened, assigned]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 1
+
+      - uses: anthropics/claude-code-action@c281e17d7fbbea390fc94d336d6b7904f10d2a41 # v1.0.84
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -1,0 +1,27 @@
+name: Claude PR Review
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  review:
+    # Only run for same-repo PRs — fork PRs have no access to secrets and could
+    # contain malicious content; fork contributors can request review via @claude
+    # once a collaborator approves the workflow run.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: anthropics/claude-code-action@c281e17d7fbbea390fc94d336d6b7904f10d2a41 # v1.0.84
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          direct_prompt: |
+            Review this pull request. Focus on:
+            - Correctness and soundness of Rust code
+            - Adherence to conventions in CLAUDE.md (conventional commits, minimal abstractions, no docstrings on unchanged code)
+            - Potential issues with wasm32-unknown-unknown compilation
+            - Any unsafe code or unsound patterns
+            Post a single consolidated review comment with your findings.


### PR DESCRIPTION
claude-pr-review.yml: auto-reviews same-repo PRs on open/sync using
pull_request_target, gated to exclude forks.

claude-interactive.yml: responds to @claude mentions in PR comments,
review comments, review bodies, and issues.

Both pin anthropics/claude-code-action@c281e17d # v1.0.84.

https://claude.ai/code/session_01XkokaoWWhHT1jHdRGnSejd