### PR TITLE
ci: add Rust build and test status checks for PRs targeting main

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: Test
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # master
+        with:
+          toolchain: 1.94.0
+          targets: wasm32-unknown-unknown
+
+      - uses: Swatinem/rust-cache@bc2d2e71bd35c5549942babaa51a89c586b981d1 # v2.8.1
+
+      - run: cargo check --target wasm32-unknown-unknown
+
+      - run: cargo build
+
+      - run: cargo test


### PR DESCRIPTION
Introduces test.yml workflow that enforces build and test passes as
status checks on pull requests to main branch. Includes verification
of wasm32-unknown-unknown target compilation and full test suite.

https://claude.ai/code/session_01VFCE5rK94tmGj4Mg2dpU3d