### PR TITLE
ci: allow git fetch and git pull --rebase without permission prompts

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "https://json.schemastore.org/claude-code-settings.json",
+    "permissions": {
+        "allow": [
+            "Bash(git fetch)",
+            "Bash(git fetch *)",
+            "Bash(git pull --rebase)",
+            "Bash(git pull --rebase *)"
+        ]
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `.claude/settings.json` with project-level Claude Code permissions
- Approves `git fetch` and `git pull --rebase` (with and without extra args) so these read-only/rebase-only git operations don't trigger permission prompts

## Test plan

- [ ] Verify `git fetch` runs without a permission prompt in a Claude Code session on this repo
- [ ] Verify `git pull --rebase` runs without a permission prompt
- [ ] Verify other git operations (e.g. `git push`) still prompt as expected

https://claude.ai/code/session_01FaUsuhhfUipqE17CoBMGoW

---
_Generated by [Claude Code](https://claude.ai/code/session_01FaUsuhhfUipqE17CoBMGoW)_