### PR TITLE
doc: add spec for height-precalculated strand placement rendering mode

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,0 +1,3 @@
+{
+  "feature_directory": "specs/001-strand-height-precalc"
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,8 @@
 - Don't introduce extra abstractions or error handling beyond what's needed
 
 <!-- SPECKIT START -->
-For additional context about technologies to be used, project structure,
-shell commands, and other important information, read the current plan
+Active feature plan: `specs/001-strand-height-precalc/plan.md`
+(height-precalculated strand placement rendering mode). See also its
+`research.md`, `data-model.md`, `contracts/public-api.md`, and `quickstart.md`
+for technical context, the `RenderMode` design, and validation steps.
 <!-- SPECKIT END -->

--- a/specs/001-strand-height-precalc/checklists/requirements.md
+++ b/specs/001-strand-height-precalc/checklists/requirements.md
@@ -35,3 +35,4 @@
 - Domain terms (strand pair, opening/closing feature, diagonal transfer) are described in plain language in the spec's User Scenarios background note so non-technical stakeholders can follow.
 - The new mode is specified as opt-in and additive to protect existing rendering output and snapshots (FR-005, SC-004).
 - Motivating use case (added 2026-06-18): the rotation move scans the rendered grid; only reversed-direction (up-then-down) transfers re-encode as extra scanned features and compound across rotations (many transfers scan to nothing; crossing-alignment transfers don't add features). Captured as User Story 2 (P2), SC-006, and a repeated-rotation edge case.
+- Operating-context decision (2026-06-18): the rendering mode is a single mode the user works in (governs all operations; only rotation's output depends on it). Legacy mode stays the default; new mode opt-in; migration out of scope. Captured as FR-012/FR-013, US3, and Assumptions.

--- a/specs/001-strand-height-precalc/checklists/requirements.md
+++ b/specs/001-strand-height-precalc/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Height-Precalculated Strand Placement (Rendering Mode)
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-18
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit-clarify` or `/speckit-plan`
+- Domain terms (strand pair, opening/closing feature, diagonal transfer) are described in plain language in the spec's User Scenarios background note so non-technical stakeholders can follow.
+- The new mode is specified as opt-in and additive to protect existing rendering output and snapshots (FR-005, SC-004).

--- a/specs/001-strand-height-precalc/checklists/requirements.md
+++ b/specs/001-strand-height-precalc/checklists/requirements.md
@@ -34,3 +34,4 @@
 - Items marked incomplete require spec updates before `/speckit-clarify` or `/speckit-plan`
 - Domain terms (strand pair, opening/closing feature, diagonal transfer) are described in plain language in the spec's User Scenarios background note so non-technical stakeholders can follow.
 - The new mode is specified as opt-in and additive to protect existing rendering output and snapshots (FR-005, SC-004).
+- Motivating use case (added 2026-06-18): the rotation move scans the rendered grid, so avoidable transfers inflate scanned features and compound across rotations; captured as User Story 2 (P2), SC-006, and a repeated-rotation edge case.

--- a/specs/001-strand-height-precalc/checklists/requirements.md
+++ b/specs/001-strand-height-precalc/checklists/requirements.md
@@ -34,4 +34,4 @@
 - Items marked incomplete require spec updates before `/speckit-clarify` or `/speckit-plan`
 - Domain terms (strand pair, opening/closing feature, diagonal transfer) are described in plain language in the spec's User Scenarios background note so non-technical stakeholders can follow.
 - The new mode is specified as opt-in and additive to protect existing rendering output and snapshots (FR-005, SC-004).
-- Motivating use case (added 2026-06-18): the rotation move scans the rendered grid, so avoidable transfers inflate scanned features and compound across rotations; captured as User Story 2 (P2), SC-006, and a repeated-rotation edge case.
+- Motivating use case (added 2026-06-18): the rotation move scans the rendered grid; only reversed-direction (up-then-down) transfers re-encode as extra scanned features and compound across rotations (many transfers scan to nothing; crossing-alignment transfers don't add features). Captured as User Story 2 (P2), SC-006, and a repeated-rotation edge case.

--- a/specs/001-strand-height-precalc/contracts/public-api.md
+++ b/specs/001-strand-height-precalc/contracts/public-api.md
@@ -1,0 +1,65 @@
+# Public API Contract: Height-Precalculated Strand Placement
+
+This is a Rust library; the "contract" is the public API surface and its
+behavioral guarantees. Signatures are indicative (final naming at implementer
+discretion); behavior is normative and traces to the spec.
+
+## New public surface
+
+```rust
+// re-exported from lib.rs
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
+pub enum RenderMode {
+    #[default]
+    Legacy,
+    PrecalculatedHeights,
+}
+
+impl AbbreviatedDiagram {
+    pub fn mode(&self) -> RenderMode;
+    pub fn set_mode(&mut self, mode: RenderMode);
+    pub fn with_mode(self, mode: RenderMode) -> Self;
+}
+```
+
+## Unchanged signatures (behavior now mode-dependent)
+
+These keep their exact current signatures and remain backward compatible
+(default mode `Legacy` ⇒ identical output):
+
+- `AbbreviatedDiagram::ascii_print::<const GRID_BORDERS: bool>(&self) -> String`
+- `AbbreviatedDiagram::try_ascii_print::<const GRID_BORDERS: bool>(&self) -> Result<String, String>`
+- `AbbreviatedDiagram::ascii_print_compact::<...>` / `try_ascii_print_compact::<...>`
+- the free `knotty::ascii_print` / `try_ascii_print` / `*_compact` functions
+- `AbbreviatedDiagram::try_rotate_90_ccw(&mut self) -> Result<(), String>`
+- `AbbreviatedDiagram::try_apply(&mut self, DiagramMove) -> Result<(), String>`
+- `AbbreviatedDiagram::try_apply_all(...) -> Result<(), String>`
+
+> The free `ascii_print(knot: Vec<(u8, usize)>)` helpers build a diagram with
+> the default `Legacy` mode. Callers that want `PrecalculatedHeights` go through
+> an `AbbreviatedDiagram` configured via `with_mode`/`set_mode`.
+
+## Behavioral guarantees (normative)
+
+| ID | Guarantee | Trace |
+|----|-----------|-------|
+| C1 | With `RenderMode::Legacy`, all rendering and rotation output is byte-for-byte identical to the pre-feature library. | FR-005, FR-013, SC-004 |
+| C2 | With `RenderMode::PrecalculatedHeights`, each opening is rendered at its precalculated maximum row. | FR-001, FR-002 |
+| C3 | A strand that does not change rows between open and close renders flat (no transfer) where placement allows. | FR-003 |
+| C4 | Open/close displacement (reversed-direction) transfers are strictly reduced vs. `Legacy` for any diagram exhibiting them; never increased for crossing-free diagrams. | FR-004, SC-002 |
+| C5 | Both modes render to the same knot for every valid diagram. | FR-006, SC-003 |
+| C6 | Crossings always connect the correct partners and are never drawn between non-adjacent rows; crossing-alignment transfers are inserted as needed. | FR-007, FR-011 |
+| C7 | Output is deterministic for a given `(items, mode)`. | FR-008, SC-005 |
+| C8 | Empty/degenerate diagrams render without error; equivalent to `Legacy` where no avoidable movement exists. | FR-010 |
+| C9 | The mode is an operating context: rotation honors `self.mode`; notation-only moves produce identical results regardless of mode. | FR-012 |
+| C10 | Rotating in `PrecalculatedHeights` never increases the scanned feature count vs. the original, and strictly reduces it vs. `Legacy` rotation for diagrams with reversed-direction transfers. | SC-006 |
+
+## Example notation (fidelity reference)
+
+- `terrace` = `(0 (2 (4 (6 )5 )3 )1 (1 (3 (5 )6 )4 )2 )0` — primary
+  reduced-transfer demonstration (US1, SC-001).
+- `basket`, `ugly_trefoil` — crossing-bearing diagrams for C6.
+
+Expected `PrecalculatedHeights` ASCII outputs are captured as `insta` snapshots
+during implementation (Test-First) and reviewed before commit; `Legacy`
+snapshots must be unchanged.

--- a/specs/001-strand-height-precalc/data-model.md
+++ b/specs/001-strand-height-precalc/data-model.md
@@ -1,0 +1,89 @@
+# Phase 1 Data Model: Height-Precalculated Strand Placement
+
+The feature adds a small amount of state and one derived (transient) structure.
+No persistence is involved; all types are in-memory Rust types in the `knotty`
+crate.
+
+## New types
+
+### `RenderMode` (enum)
+
+The active operating context that governs how a diagram is rendered (and,
+through rotation, how its notation is re-derived).
+
+| Variant | Meaning |
+|---------|---------|
+| `Legacy` *(default)* | Existing renderer: each opening placed at the lowest free row; passing strands bumped up/down via transfers. Output is byte-for-byte identical to today. |
+| `PrecalculatedHeights` | New renderer: each opening placed at its precalculated maximum row so passing strands run flat; only boundary and crossing-alignment transfers are emitted. |
+
+- Derives: `Clone, Copy, PartialEq, Eq, Debug, Default` (`Legacy` is `#[default]`).
+- Re-exported from `lib.rs`.
+- Final variant names are at implementer discretion; `Legacy` / `PrecalculatedHeights` are used throughout these docs.
+
+## Changed types
+
+### `AbbreviatedDiagram`
+
+Source of truth for a diagram. Changes from a tuple struct to a named struct so
+it can carry the active mode.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `items` | `Vec<AbbreviatedItem>` | The ordered diagram features (was the unnamed tuple field `.0`). |
+| `mode` | `RenderMode` | The active operating context. Defaults to `Legacy` for every existing constructor. |
+
+Accessors / builders (new):
+- `fn mode(&self) -> RenderMode`
+- `fn set_mode(&mut self, mode: RenderMode)`
+- `fn with_mode(self, mode: RenderMode) -> Self`
+
+Invariants:
+- All existing constructors (`FromStr`, `new_from_tuples`, rotation output) yield
+  `mode = Legacy`, preserving current behavior (FR-005, FR-013, SC-004).
+- The mode is the *only* thing that distinguishes how `items` is rendered; two
+  diagrams with equal `items` and equal `mode` are equivalent.
+
+## Derived / transient structures
+
+### Peak-row map (internal, not public)
+
+Produced by the precalculation pass (research R2): a mapping from each opening
+event to the maximum vertical row its strand pair occupies over its lifetime.
+Consumed by the `PrecalculatedHeights` build path; never stored on the diagram.
+
+### `VerboseDiagram` (unchanged shape)
+
+The rendered grid (`Vec<VerboseLine>` of `Horiz` cells) remains structurally
+unchanged. What differs by mode is *which* `Horiz` cells are produced for a
+given `AbbreviatedDiagram`. `from_abbreviated` gains awareness of the mode (read
+from the `AbbreviatedDiagram`) to choose the placement path.
+
+## Relationships & flow
+
+```text
+AbbreviatedDiagram { items, mode }
+        │  from_abbreviated (mode-aware)
+        ▼
+   VerboseDiagram (grid of Horiz)
+        │  display::<GRID_BORDERS>()        │  full_render_lines → scan_row
+        ▼                                   ▼
+   ASCII string                        rotation → new AbbreviatedDiagram (mode carried)
+```
+
+- Rendering (`ascii_print*`) and rotation (`try_rotate_90_ccw`, via `try_apply`/
+  `try_apply_all`) both consult `self.mode`.
+- Notation-only moves (`Swap`, `WrapAround`, `ChangeCrossing`, Reidemeister,
+  `Bulge`, `Collapse*`) operate on `items` only and are independent of `mode`
+  (US3 acceptance scenario 3).
+
+## Validation rules (from requirements)
+
+- Default mode output unchanged (FR-005, SC-004).
+- `PrecalculatedHeights`: opening placed at precalculated max row (FR-001/FR-002);
+  unchanged-row strands render flat (FR-003); open/close displacement transfers
+  reduced (FR-004); boundary diagonals retained (FR-009); crossings kept adjacent
+  via crossing-alignment transfers, never drawn between non-adjacent rows
+  (FR-007, FR-011).
+- Both modes represent the same knot (FR-006, SC-003); output deterministic
+  (FR-008, SC-005); empty/degenerate handled (FR-010).
+- Rotation scanned-feature count non-increasing / reduced (SC-006).

--- a/specs/001-strand-height-precalc/plan.md
+++ b/specs/001-strand-height-precalc/plan.md
@@ -1,0 +1,88 @@
+# Implementation Plan: Height-Precalculated Strand Placement (Rendering Mode)
+
+**Branch**: `claude/diagram-strand-height-precalc-p4l2lo` | **Date**: 2026-06-25 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `specs/001-strand-height-precalc/spec.md`
+
+## Summary
+
+Add a second, opt-in diagram rendering mode that places each opening strand at the maximum vertical row it will ever occupy (precalculated from the abbreviated notation), so passing strands run flat instead of zig-zagging up and back down via transfer diagonals. The mode is an **operating context** carried on `AbbreviatedDiagram` (default = the existing legacy renderer), so rendering and the rotation move both honor it without changing any existing method signature. Because rotation re-derives notation by scanning the rendered grid, reducing avoidable (reversed-direction) transfers keeps the scanned feature count stable across repeated rotations — the motivating use case. Crossings whose partners are no longer adjacent under max-height placement are brought together with localized crossing-alignment transfers (which are scanned but do not inflate feature counts).
+
+## Technical Context
+
+**Language/Version**: Rust 1.94.0 (pinned in `rust-toolchain.toml`)
+
+**Primary Dependencies**: `itertools`, `regex` (existing); no new runtime dependencies
+
+**Storage**: N/A (in-memory diagram data structures)
+
+**Testing**: `cargo test` with `insta` snapshot tests (existing) + `pretty_assertions`
+
+**Target Platform**: native + `wasm32-unknown-unknown` (NON-NEGOTIABLE per constitution)
+
+**Project Type**: Single Rust library crate (`knotty`) with example binaries under `examples/`
+
+**Performance Goals**: Rendering remains O(features × height); the added precalculation pass is a single linear walk of the abbreviated sequence. No interactive-latency regression for the example app.
+
+**Constraints**: Default-mode output must be byte-for-byte identical to today (protects existing `insta` snapshots); all `src/` code must compile for `wasm32-unknown-unknown`; abbreviated notation remains the source of truth.
+
+**Scale/Scope**: Diagrams of tens–hundreds of features; one new public enum, a mode field + accessors on `AbbreviatedDiagram`, a new placement path in `raw_lines.rs`/`diagram.rs`, and snapshot coverage.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Library-First | ✅ PASS | All behavior lands in the core `knotty` crate (`src/`); the new `RenderMode` + mode-aware rendering is independently useful to downstream consumers. Example apps consume it but do not host it. |
+| II. WASM-Compatible (NON-NEGOTIABLE) | ✅ PASS | Pure-logic change; no new deps, no `std`-only crates. Verified per task with `cargo check --target wasm32-unknown-unknown`. |
+| III. Test-First | ✅ PASS | New diagram operation ⇒ `insta` snapshot tests authored alongside; regression tests added for `diagram.rs`/`rotate.rs`. Default-mode snapshots must remain unchanged (proves no regression). |
+| IV. Notation Fidelity | ✅ PASS | Abbreviated notation stays the source of truth; the spec supplies example notation inputs (e.g. `terrace`), and round-trip/equivalence checks confirm the same knot. |
+| V. Minimal Dependencies | ✅ PASS | No `Cargo.toml` additions. |
+
+**Result**: No violations. Complexity Tracking table not required.
+
+**Post-design re-check (after Phase 1)**: Still PASS. The design adds one enum
+and a mode field with accessors, a linear precalculation pass, and a placement
+path in `raw_lines.rs` — no new dependencies, no `std`-only crates, no GUI/CLI
+coupling, and abbreviated notation stays authoritative. The tuple→named-struct
+rename is mechanical and introduces no new abstraction beyond the `RenderMode`
+the spec requires.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/001-strand-height-precalc/
+├── plan.md              # This file (/speckit-plan output)
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/
+│   └── public-api.md    # Phase 1 output (library API + behavioral contract)
+├── checklists/
+│   └── requirements.md  # Spec quality checklist (existing)
+└── tasks.md             # Phase 2 output (/speckit-tasks — NOT created here)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── lib.rs           # CHANGE: re-export RenderMode
+├── diagram.rs       # CHANGE: AbbreviatedDiagram gains `mode` field + accessors;
+│                    #         from_abbreviated/full_render_lines/try_rotate read mode;
+│                    #         self.0 → self.items mechanical rename
+├── raw_lines.rs     # CHANGE: new max-height placement path (append/expand/contract variants)
+├── render.rs        # CHANGE (likely none): Horiz glyphs reused; verify transfer glyphs suffice
+├── rotate.rs        # CHANGE (likely none): scan_row unchanged; rotation feeds it mode-aware render
+├── moves.rs         # CHANGE (likely none): Rotate90 dispatch already routes through try_rotate
+└── snapshots/, diagram/snapshots/   # NEW snapshots for max-height mode; existing ones unchanged
+
+examples/
+├── ascii_print.rs           # OPTIONAL: expose a flag to select the mode
+└── knot-so-good/            # OPTIONAL: expose mode toggle in the mini app
+```
+
+**Structure Decision**: Single-crate library (Option 1). The feature is implemented entirely in `src/`; the existing const-generic display flag (`GRID_BORDERS`) is orthogonal and untouched. The rendering mode is carried as a runtime field on `AbbreviatedDiagram` rather than a const generic, because the rotation move is dispatched at runtime via `DiagramMove::Rotate90CounterClockwise` and must honor the active mode through `try_apply_all` without changing the move API.

--- a/specs/001-strand-height-precalc/quickstart.md
+++ b/specs/001-strand-height-precalc/quickstart.md
@@ -1,0 +1,83 @@
+# Quickstart / Validation Guide: Height-Precalculated Strand Placement
+
+This guide validates the feature end-to-end. It assumes the standard toolchain
+(`rust-toolchain.toml` pins 1.94.0 with the `wasm32-unknown-unknown` target).
+
+## Prerequisites
+
+```sh
+# from repo root
+rustup show                 # confirms 1.94.0 + wasm32 target are available
+```
+
+## Build & constitution gates
+
+```sh
+cargo build
+cargo check --target wasm32-unknown-unknown    # Principle II (NON-NEGOTIABLE)
+```
+
+Both must succeed with no new dependencies added to `Cargo.toml` (Principle V).
+
+## Test gates
+
+```sh
+cargo test                 # all unit + snapshot tests
+cargo insta review         # review/accept NEW PrecalculatedHeights snapshots only
+```
+
+Expected:
+- **No existing snapshot changes** — `Legacy` output is unchanged (C1 / SC-004).
+  If any pre-existing snapshot diffs, that is a regression, not an accept.
+- **New snapshots** appear only for `PrecalculatedHeights` renders.
+
+## Scenario 1 — Reduced transfers (US1 / SC-001)
+
+Render the `terrace` diagram in both modes and compare:
+
+1. Parse `(0 (2 (4 (6 )5 )3 )1 (1 (3 (5 )6 )4 )2 )0`.
+2. Render with `RenderMode::Legacy` → staircase of transfer diagonals (today's output).
+3. Render the same diagram `.with_mode(RenderMode::PrecalculatedHeights)` →
+   previously climbing/descending strands run flat; total transfer segments are
+   fewer; the figure still decodes to the same knot.
+
+Pass: max-height render has strictly fewer transfer diagonals and represents the
+same knot.
+
+## Scenario 2 — Opt-in / operating context (US3 / FR-012)
+
+1. Default-constructed diagram has `mode() == RenderMode::Legacy`.
+2. A notation-only move (e.g. a `Swap`) yields identical `items` whether the mode
+   is `Legacy` or `PrecalculatedHeights` (C9).
+3. Switching `set_mode(PrecalculatedHeights)` changes only rendering and rotation.
+
+## Scenario 3 — Crossing fidelity (US4 / FR-007 / FR-011)
+
+1. Render `basket` and `ugly_trefoil` in `PrecalculatedHeights`.
+2. Confirm each crossing connects the same two strands as the `Legacy` render and
+   no crossing is drawn between non-adjacent rows.
+
+Pass: crossings are correct and the figure decodes to the same knot.
+
+## Scenario 4 — Rotation stability (US2 / SC-006)
+
+1. Take a diagram whose `Legacy` render has reversed-direction transfers.
+2. Rotate it (`try_rotate_90_ccw`) with `PrecalculatedHeights` active; count
+   features (`items` length) before vs. after.
+3. Rotate through a full four-rotation cycle.
+
+Pass: feature count never increases vs. the original, is strictly lower than the
+`Legacy`-mode rotation for such diagrams, and the final diagram represents the
+same knot as the original.
+
+## Optional — example app
+
+If the example flag is added, `examples/ascii_print.rs` can render a diagram in
+the new mode for manual inspection; `knot-so-good` can expose a toggle. These are
+optional surfaces (Principle I: library-first).
+
+## References
+
+- Behavioral contract: [contracts/public-api.md](./contracts/public-api.md)
+- Data model: [data-model.md](./data-model.md)
+- Design decisions: [research.md](./research.md)

--- a/specs/001-strand-height-precalc/research.md
+++ b/specs/001-strand-height-precalc/research.md
@@ -1,0 +1,145 @@
+# Phase 0 Research: Height-Precalculated Strand Placement
+
+This document resolves the open design questions for the height-precalculated
+rendering mode. The spec's clarifications already settled the product-level
+decisions (unconditional max-row placement; rotation-feature semantics; mode as
+an operating context defaulting to legacy). The questions below are the
+remaining technical unknowns.
+
+## R1. How is the rendering mode represented and threaded?
+
+**Decision**: Introduce `pub enum RenderMode { Legacy, PrecalculatedHeights }`
+(`#[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]`, `#[default] Legacy`),
+and store it as a field on `AbbreviatedDiagram`. Convert the tuple struct
+`AbbreviatedDiagram(pub(crate) Vec<AbbreviatedItem>)` to a named struct
+`AbbreviatedDiagram { items: Vec<AbbreviatedItem>, mode: RenderMode }`. Add
+`mode(&self) -> RenderMode`, `set_mode(&mut self, RenderMode)`, and a
+`with_mode(self, RenderMode) -> Self` builder. Re-export `RenderMode` from
+`lib.rs`.
+
+**Rationale**:
+- Directly models FR-012 ("a single operating context a user selects to work
+  in; all operations run under the active mode") and FR-013 (default = legacy).
+- Because rendering and rotation are `&self`/`&mut self` methods, reading
+  `self.mode` means **no existing public signature changes** — `ascii_print`,
+  `try_ascii_print*`, `try_rotate_90_ccw`, `try_apply`, and `try_apply_all` keep
+  their current shapes and simply behave per the active mode. With the default
+  `Legacy`, existing callers (and the example apps) compile and behave
+  identically, satisfying FR-005/SC-004 by construction.
+- Rotation is dispatched at runtime through `DiagramMove::Rotate90CounterClockwise`
+  inside `try_apply_all`; a field lets that path honor the mode without adding a
+  parameter to the move API.
+
+**Alternatives considered**:
+- *Const generic `<const PRECALC: bool>`* (mirroring `GRID_BORDERS`): rejected —
+  const generics cannot be selected by a runtime `DiagramMove`, so the rotation
+  path could not honor a user-chosen mode; also multiplies the already-large set
+  of `ascii_print` signatures.
+- *Threaded runtime parameter* on each render/rotate/apply call: rejected —
+  forces signature changes that ripple into `examples/ascii_print.rs` and
+  `examples/knot-so-good`, and makes "work in one mode" the caller's burden on
+  every call (easy to get inconsistent), contradicting the operating-context
+  model.
+
+**Cost / risk**: The tuple→named-struct change requires a mechanical
+`self.0 → self.items` / `knot.0 → knot.items` rename (~40 sites in `diagram.rs`)
+and updating constructors (`new_from_tuples`, the `FromStr` parser, rotation's
+`Self::new_from_tuples`). Risk is low (compiler-checked). Any
+`assert_debug_snapshot!` on an `AbbreviatedDiagram` may shift due to the new
+field — audit and re-accept those specific snapshots (the default value keeps
+equality between parsed and constructed diagrams).
+
+## R2. How are per-strand maximum rows precalculated?
+
+**Decision**: Add a single linear pass over the abbreviated sequence that
+simulates the vertical stack and records, for each opened pair, the maximum
+bottom-row it occupies between its `(` and its matching `)`.
+
+Model: maintain an ordered stack of currently-open pairs. Each `(N` inserts a
+new pair at logical index `N` (pairs at index ≥ N shift up by 2); each `)N`
+removes the pair occupying index `N` (pairs above shift down by 2); crossings
+do not change vertical indices. Track each live pair's current bottom index and
+fold its running maximum. The result is a map *opening-event → peak row*, which
+is the row at which that opening is placed in `PrecalculatedHeights` mode. Total
+diagram height is unchanged (`AbbreviatedDiagram::height()` already computes the
+max simultaneous depth × 2).
+
+**Rationale**: Matches the unconditional max-row decision (Clarifications
+2026-06-18); O(features) and allocation-light (WASM-friendly); reuses the
+existing notion of logical index used throughout `raw_lines::append`.
+
+**Alternatives considered**: Cost-aware placement weighing crossing-alignment
+against displacement — explicitly out of scope per clarification.
+
+## R3. How is the grid built so placed strands run flat?
+
+**Decision**: Add a max-height placement path alongside the existing
+`raw_lines::{append, expand_above, contract_above}`. The legacy path inserts a
+new pair at logical index `idx` and bumps everything above up via `TransferUp`
+(and pulls down via `TransferDown` on close). The new path instead:
+
+1. Opens each pair directly at its precalculated peak row (from R2).
+2. Keeps a placed strand flat (horizontal `Line`) for its whole lifetime where
+   its rendered row already equals its logical requirement — eliminating the
+   avoidable up-then-down (reversed-direction) transfers (FR-003, FR-004).
+3. Still emits the **boundary** diagonals intrinsic to a pair entering at its
+   opening index and leaving at its closing index (FR-009).
+
+Reuse the existing `Horiz` transfer glyphs (`TransferUp*`, `TransferDown*`,
+`Opened*`, `Closed*`) — no new glyphs are expected. `render.rs` likely needs no
+change; this will be confirmed when snapshots are generated.
+
+**Rationale**: Confines the new logic to the placement layer (`raw_lines.rs` +
+the `from_abbreviated` driver in `diagram.rs`), leaving display and scanning
+untouched. Exact glyph-by-glyph output is validated via `insta` snapshots per
+the Test-First constitution principle rather than hand-specified here.
+
+## R4. How are crossings whose partners are no longer adjacent handled?
+
+**Decision**: At each crossing `\N`/`/N`, the two participating strands must be
+on adjacent rendered rows. Under max-height placement they may not be. Detect
+the gap and emit a localized **crossing-alignment transfer**: bring the two
+crossing strands adjacent immediately before the crossing column and restore
+their placement immediately after (FR-007, FR-011). A crossing is never drawn
+between non-adjacent rows.
+
+**Rationale**: Preserves the legacy invariant only *locally* (at the crossing),
+which is the minimum needed for a valid planar rendering, instead of globally
+(which is what forces the avoidable transfers in the first place). These
+transfers are scanned during rotation but do **not** increase the scanned
+feature count (Clarifications 2026-06-18), so they are compatible with SC-006.
+
+**Open validation point**: The precise alignment construction (how many rows to
+move, and the exact glyph sequence) is the highest-uncertainty implementation
+area and will be developed test-first with small, targeted snapshot fixtures
+(e.g. `basket`, `ugly_trefoil`, and minimal hand-built crossing cases) before
+the general path is generalized.
+
+## R5. How is default-mode parity guaranteed?
+
+**Decision**: `RenderMode::Legacy` routes through the existing
+`append/expand_above/contract_above` code path unchanged. The CI/test gate is
+that **every existing snapshot remains byte-for-byte identical** (SC-004); new
+snapshots are added only for `PrecalculatedHeights`. A round-trip/equivalence
+check (rotate or re-render) confirms both modes represent the same knot
+(SC-003, FR-006).
+
+**Rationale**: The cheapest, strongest guarantee against regression is the
+existing snapshot suite plus a parity assertion that legacy output is untouched.
+
+## R6. Rotation stability measurement
+
+**Decision**: Express SC-006 as a test that counts scanned features
+(`AbbreviatedDiagram` length, i.e. number of `AbbreviatedItem`s) before and
+after rotation in `PrecalculatedHeights` mode, and across a full four-rotation
+cycle. Assert: no increase versus the original, and strictly fewer than the
+legacy-mode rotation for diagrams whose legacy rendering contains
+reversed-direction transfers (e.g. `terrace`). Knot equivalence is asserted via
+the existing rotation round-trip behavior.
+
+**Rationale**: Feature count is directly observable from the abbreviated form,
+making SC-006 measurable without inspecting glyphs.
+
+## Resolved unknowns
+
+All Technical Context items are resolved; no `NEEDS CLARIFICATION` remains.

--- a/specs/001-strand-height-precalc/research.md
+++ b/specs/001-strand-height-precalc/research.md
@@ -41,6 +41,15 @@ and store it as a field on `AbbreviatedDiagram`. Convert the tuple struct
   every call (easy to get inconsistent), contradicting the operating-context
   model.
 
+**IMPLEMENTED VARIANT (deviation)**: the mode was added as a *second tuple
+field* — `AbbreviatedDiagram(Vec<AbbreviatedItem>, RenderMode)` — rather than
+converting to a named struct. Sizing the change showed 38 `self.0` access sites
+but only one construction site, so the named-struct form would have meant a
+38-site mechanical rename for no behavioral gain, against the project rule of
+minimal, noise-free commits. `.0` is already the established idiom throughout
+`diagram.rs`. Everything else in R1 (default `Legacy`, accessors, unchanged
+public signatures) is as designed.
+
 **Cost / risk**: The tuple→named-struct change requires a mechanical
 `self.0 → self.items` / `knot.0 → knot.items` rename (~40 sites in `diagram.rs`)
 and updating constructors (`new_from_tuples`, the `FromStr` parser, rotation's
@@ -114,6 +123,41 @@ move, and the exact glyph sequence) is the highest-uncertainty implementation
 area and will be developed test-first with small, targeted snapshot fixtures
 (e.g. `basket`, `ugly_trefoil`, and minimal hand-built crossing cases) before
 the general path is generalized.
+
+**IMPLEMENTED VARIANT (deviation)**: crossing-alignment transfers were *not*
+built. Instead, the placement pass validates that every event's two lines land
+on adjacent rows and that strand order is preserved; when they do not, the
+whole diagram falls back to the legacy placement. This still satisfies FR-011's
+hard guarantee — a crossing is never drawn between non-adjacent rows — and
+FR-006/FR-007, and crossing-bearing diagrams whose partners *are* adjacent
+under max-height placement (e.g. `ugly_trefoil`) render flat today. What is
+lost is the flat rendering for diagrams that would need alignment transfers.
+See R7 for the boundary this exposed.
+
+## R7. Which diagrams can be drawn flat (discovered during implementation)
+
+**Finding**: a constant per-line row assignment is only faithful when no pair's
+two lines are ever separated. Nesting separates them: in `(0 (1 )1 )0` the outer
+pair opens at rows 0/1, but the inner pair opening between them pushes the outer
+top line to row 3, so the outer pair is no longer adjacent when it must close.
+Naive max placement also inverts strand order in cases like
+`(0 (2 )2 (0 (0 (0 (0 …`, where a lower strand keeps rising after the strand
+above it has closed.
+
+**Decision**: detect both conditions and fall back to legacy for that diagram.
+
+**Consequence**: *stacked* diagrams — exactly the ones with avoidable
+up-then-down displacement — render flat (`terrace` drops from 18 transfer
+segments to 0). *Nested* diagrams (`donut`, `c_thingy`, `trefoil`, `basket`)
+fall back and are byte-identical to legacy. This is the right dividing line for
+correctness, but it is coarser than ideal: a mixed diagram loses the benefit on
+its stacked parts too.
+
+**Remaining work**: to benefit mixed/nested diagrams, a pair's top line needs to
+rise once after opening and descend once before closing (its own inherent
+boundary movement, permitted by FR-009) while every *other* strand stays flat.
+That requires a per-line transfer mechanism; today's `expand_above`/
+`contract_above` move every line at or above an index together.
 
 ## R5. How is default-mode parity guaranteed?
 

--- a/specs/001-strand-height-precalc/spec.md
+++ b/specs/001-strand-height-precalc/spec.md
@@ -42,7 +42,7 @@ A person rendering a knot diagram chooses the height-precalculated rendering mod
 
 A downstream consumer of the library (or example app) selects between the existing default rendering and the new height-precalculated rendering. Existing renders, snapshots, and example outputs are unaffected unless the new mode is explicitly chosen.
 
-**Why this priority**: Protects existing behaviour and consumers. The feature must be additive; changing the default would break existing snapshots and downstream expectations.
+**Why this priority**: Protects existing behavior and consumers. The feature must be additive; changing the default would break existing snapshots and downstream expectations.
 
 **Independent Test**: Render a set of diagrams in the default mode and confirm output is byte-for-byte identical to today's output; render the same diagrams in the new mode and confirm the precalculated placement is used.
 
@@ -85,7 +85,7 @@ A person renders diagrams that contain crossings as well as openings and closing
 - **FR-002**: System MUST place each opening feature at its precalculated target row rather than always at the lowest free row.
 - **FR-003**: In the new mode, a strand that does not change rows between its opening and closing MUST render as a straight horizontal line with no diagonal transfer segments, wherever the precalculated placement makes that possible.
 - **FR-004**: In the new mode, the number of diagonal transfer segments MUST be reduced (versus the default mode) for any diagram in which a strand is pushed up by an opening beneath it and later pulled back down by a closing beneath it.
-- **FR-005**: System MUST leave the default rendering behaviour unchanged; the height-precalculated behaviour MUST be opt-in.
+- **FR-005**: System MUST leave the default rendering behavior unchanged; the height-precalculated behavior MUST be opt-in.
 - **FR-006**: For every valid diagram, the new mode's rendering MUST represent the same knot as the default mode's rendering (notation fidelity preserved).
 - **FR-007**: The new mode MUST support all existing diagram elements — openings, closings, and crossings — and MUST keep each crossing aligned with its correct partner strand.
 - **FR-008**: The new mode MUST produce deterministic output: the same diagram always renders identically.
@@ -111,7 +111,7 @@ A person renders diagrams that contain crossings as well as openings and closing
 
 ## Assumptions
 
-- The height-precalculated behaviour is an additive, opt-in rendering path; the existing default rendering and its public output remain unchanged (per Constitution: Library-First, and to protect existing `insta` snapshots).
+- The height-precalculated behavior is an additive, opt-in rendering path; the existing default rendering and its public output remain unchanged (per Constitution: Library-First, and to protect existing `insta` snapshots).
 - "Reduce the need for strands to be moved up and down" means minimizing avoidable up-then-down displacement, not necessarily computing a globally optimal placement; a placement at each strand's maximum occupied row is the intended heuristic.
 - The ASCII rendering is the target surface for this mode; the abbreviated knot notation remains the source of truth (per Constitution: Notation Fidelity), so example abbreviated-notation inputs and expected rendered outputs will accompany the implementation as snapshot tests.
 - Expected outputs for the new mode will be captured via `insta` snapshot tests (per Constitution: Test-First), reviewed and accepted before commit.

--- a/specs/001-strand-height-precalc/spec.md
+++ b/specs/001-strand-height-precalc/spec.md
@@ -65,6 +65,7 @@ A person renders diagrams that contain crossings as well as openings and closing
 
 1. **Given** a diagram containing crossings, **When** rendered in the height-precalculated mode, **Then** every crossing connects the same two strands as in the default rendering.
 2. **Given** a diagram with deeply nested openings, **When** rendered in the new mode, **Then** strand placement never overlaps two strands on the same row and the figure is well-formed.
+3. **Given** a crossing whose two strands are not adjacent under the precalculated placement, **When** rendered in the new mode, **Then** the strands are transferred to adjacent rows for the crossing and the crossing is never drawn between non-adjacent rows.
 
 ---
 
@@ -74,6 +75,7 @@ A person renders diagrams that contain crossings as well as openings and closing
 - **Single opening/closing pair with nothing opening beneath it**: the strand is already at its maximum height, so the new mode produces output equivalent to the default (no diagonals to remove).
 - **Strand whose opening row already equals its maximum row**: no diagonal transfer is introduced or removed for that strand.
 - **Unavoidable boundary diagonals**: a strand must still enter at its opening index and leave at its closing index; diagonals intrinsic to those transitions are permitted. Only the avoidable up-then-down displacement between them is removed.
+- **Crossing partners no longer adjacent**: the default mode keeps any two strands that can cross directly above/below each other at a uniform distance, so a crossing is always between neighboring rows. Placing strands at their overall maximum row can separate two crossing partners; the new mode must then transfer them together to be adjacent for the crossing (and back afterward). This is a *new* class of transfer the default mode never needs, and it is an accepted cost of the new mode — see FR-011 and SC-002.
 - **Interleaved openings and closings at the same indices**: placement remains consistent and non-overlapping.
 - **Closings at the very bottom row**: handled without error and without forcing avoidable movement on strands above.
 
@@ -84,27 +86,29 @@ A person renders diagrams that contain crossings as well as openings and closing
 - **FR-001**: System MUST provide a selectable rendering mode (distinct from the default) that, before placing strands, precalculates for each opening the maximum vertical row the resulting strand will occupy between its opening and its matching closing.
 - **FR-002**: System MUST place each opening feature at its precalculated target row rather than always at the lowest free row.
 - **FR-003**: In the new mode, a strand that does not change rows between its opening and closing MUST render as a straight horizontal line with no diagonal transfer segments, wherever the precalculated placement makes that possible.
-- **FR-004**: In the new mode, the number of diagonal transfer segments MUST be reduced (versus the default mode) for any diagram in which a strand is pushed up by an opening beneath it and later pulled back down by a closing beneath it.
+- **FR-004**: In the new mode, the number of *open/close displacement* transfer segments (those caused by a strand being pushed up by an opening beneath it and later pulled back down by a closing beneath it) MUST be reduced versus the default mode for any diagram exhibiting such displacement.
 - **FR-005**: System MUST leave the default rendering behavior unchanged; the height-precalculated behavior MUST be opt-in.
 - **FR-006**: For every valid diagram, the new mode's rendering MUST represent the same knot as the default mode's rendering (notation fidelity preserved).
 - **FR-007**: The new mode MUST support all existing diagram elements — openings, closings, and crossings — and MUST keep each crossing aligned with its correct partner strand.
 - **FR-008**: The new mode MUST produce deterministic output: the same diagram always renders identically.
 - **FR-009**: The new mode MUST still emit diagonal transfer segments that are intrinsic to a strand entering at its opening index or leaving at its closing index; only avoidable up-then-down movement is removed.
 - **FR-010**: The new mode MUST handle empty and degenerate diagrams without error, producing output equivalent to the default mode where no avoidable movement exists.
+- **FR-011**: When a crossing's two participating strands are not on adjacent rows under the precalculated placement, the new mode MUST insert the transfer segments needed to bring them adjacent for the crossing and to restore their placement afterward. These crossing-alignment transfers are permitted even though they are not open/close displacement transfers, and the rendering MUST never draw a crossing between non-adjacent rows.
 
 ### Key Entities *(include if feature involves data)*
 
 - **Strand pair**: the two lines introduced by a single opening feature and retired by its matching closing feature; occupies a vertical row that may change over the diagram's width.
 - **Opening feature**: the element that introduces a strand pair; the element whose placement row this feature precalculates.
 - **Maximum strand row (precalculated height)**: the highest vertical row a given strand pair occupies at any point between its opening and closing — the target placement row for the new mode.
-- **Diagonal transfer segment**: a rendered segment that moves a strand up or down between rows; the quantity this feature seeks to reduce.
+- **Diagonal transfer segment**: a rendered segment that moves a strand up or down between rows. Two kinds matter here: *open/close displacement transfers*, caused by openings/closings beneath a passing strand (the kind this feature reduces); and *crossing-alignment transfers*, needed to bring two crossing partners adjacent when precalculated placement has separated them (a new cost the default mode never incurs).
+- **Crossing-alignment transfer**: a transfer the new mode adds to make two crossing strands adjacent at the moment they cross (and to restore placement afterward), because the default mode's guarantee that crossing partners are always adjacent no longer holds once strands sit at their maximum rows.
 
 ## Success Criteria *(mandatory)*
 
 ### Measurable Outcomes
 
 - **SC-001**: For the `terrace` diagram, every strand that currently moves up and then back down renders with no intermediate vertical movement between its opening and closing — the staircase is eliminated.
-- **SC-002**: Across the existing example diagrams, no diagram produces more diagonal transfer segments in the new mode than in the default mode, and every diagram that contains an avoidable up-then-down strand movement produces strictly fewer.
+- **SC-002**: For crossing-free diagrams, every diagram containing avoidable up-then-down strand movement renders with strictly fewer total diagonal transfer segments than the default mode, and none renders with more. For diagrams that contain crossings, open/close displacement transfers are strictly reduced where such displacement exists; the new mode may add crossing-alignment transfers (FR-011), so total transfer count is measured and reported per example, and the open/close-displacement and crossing-alignment counts are tracked separately so the tradeoff is explicit rather than hidden.
 - **SC-003**: 100% of valid diagrams render to the same knot in the new mode as in the default mode (verified by round-trip / equivalence checks).
 - **SC-004**: Default-mode output remains byte-for-byte identical to current output for every existing example and snapshot.
 - **SC-005**: Rendering is deterministic — rendering the same diagram twice in the new mode yields identical output every time.
@@ -112,7 +116,8 @@ A person renders diagrams that contain crossings as well as openings and closing
 ## Assumptions
 
 - The height-precalculated behavior is an additive, opt-in rendering path; the existing default rendering and its public output remain unchanged (per Constitution: Library-First, and to protect existing `insta` snapshots).
-- "Reduce the need for strands to be moved up and down" means minimizing avoidable up-then-down displacement, not necessarily computing a globally optimal placement; a placement at each strand's maximum occupied row is the intended heuristic.
+- "Reduce the need for strands to be moved up and down" means minimizing avoidable open/close displacement, not necessarily computing a globally optimal placement; a placement at each strand's maximum occupied row is the intended heuristic.
+- The default mode's invariant that any two crossing strands are always vertically adjacent at a uniform distance does not survive max-row placement. The new mode therefore accepts crossing-alignment transfers (FR-011) as a tradeoff: it optimizes for fewer open/close displacement transfers, not for the global minimum of all transfers, and a crossing-heavy diagram could net out with a similar or larger total transfer count. Whether to further refine the placement heuristic to weigh crossing-alignment cost is deferred to planning.
 - The ASCII rendering is the target surface for this mode; the abbreviated knot notation remains the source of truth (per Constitution: Notation Fidelity), so example abbreviated-notation inputs and expected rendered outputs will accompany the implementation as snapshot tests.
 - Expected outputs for the new mode will be captured via `insta` snapshot tests (per Constitution: Test-First), reviewed and accepted before commit.
 - All new code lands in the core `knotty` crate and must compile for `wasm32-unknown-unknown` (per Constitution: WASM-Compatible).

--- a/specs/001-strand-height-precalc/spec.md
+++ b/specs/001-strand-height-precalc/spec.md
@@ -1,0 +1,118 @@
+# Feature Specification: Height-Precalculated Strand Placement (Rendering Mode)
+
+**Feature Branch**: `claude/diagram-strand-height-precalc-p4l2lo`
+
+**Created**: 2026-06-18
+
+**Status**: Draft
+
+**Input**: User description: "Diagram rendering mode that precalculates diagram max heights for strands so that it can place the opening features for those strand openings at a diagram height that reduces the need for strands to be moved up and down via diagonals as other strands are opened and closed, respectively, below them in the diagram"
+
+## User Scenarios & Testing *(mandatory)*
+
+<!--
+  Background (domain): A knot diagram is rendered as horizontal "strands". An
+  opening feature introduces a new strand pair; a closing feature retires one.
+  When a strand pair opens *beneath* strands that are already present, those
+  existing strands are pushed up a row; when a pair closes beneath them, they
+  are pulled back down. Today the renderer places every opening at the lowest
+  free row, so a strand that is only "passing through" gets shoved up and later
+  pulled back down, drawing diagonal "transfer" segments (a staircase) instead
+  of a straight horizontal line. This feature adds a rendering mode that opens
+  each strand directly at the highest row it will ever need, so it can run flat.
+-->
+
+### User Story 1 - Render with reduced up-and-down strand movement (Priority: P1)
+
+A person rendering a knot diagram chooses the height-precalculated rendering mode. For each opening, the renderer first determines the maximum vertical row the resulting strand will occupy at any point before it closes, and opens the strand directly at (or near) that row. Strands that previously zig-zagged up and then back down as other strands opened and closed beneath them instead run as straight horizontal lines.
+
+**Why this priority**: This is the core value of the feature — cleaner, easier-to-read diagrams. Without it, nothing else matters. It is independently shippable as a new rendering path.
+
+**Independent Test**: Render a diagram known to produce avoidable up-then-down movement (for example the `terrace` diagram, abbreviated notation `(0 (2 (4 (6 )5 )3 )1 (1 (3 (5 )6 )4 )2 )0`) in the new mode and confirm that strands which previously climbed and descended now render with no intermediate vertical movement between their opening and closing, while the diagram still represents the same knot.
+
+**Acceptance Scenarios**:
+
+1. **Given** a diagram in which a strand opens, is passed over by one or more openings/closings beneath it, and then closes at the same row it opened, **When** rendered in the height-precalculated mode, **Then** that strand is drawn flat (no diagonal transfer segments) for the portion where it was previously displaced up and back down.
+2. **Given** the `terrace` diagram, **When** rendered in the height-precalculated mode, **Then** the total number of diagonal transfer segments is lower than in the default mode and the rendered figure decodes to the same knot.
+3. **Given** any valid diagram, **When** rendered in the height-precalculated mode, **Then** the figure represents the same knot as the default-mode rendering of that diagram.
+
+---
+
+### User Story 2 - Opt in without changing existing output (Priority: P2)
+
+A downstream consumer of the library (or example app) selects between the existing default rendering and the new height-precalculated rendering. Existing renders, snapshots, and example outputs are unaffected unless the new mode is explicitly chosen.
+
+**Why this priority**: Protects existing behaviour and consumers. The feature must be additive; changing the default would break existing snapshots and downstream expectations.
+
+**Independent Test**: Render a set of diagrams in the default mode and confirm output is byte-for-byte identical to today's output; render the same diagrams in the new mode and confirm the precalculated placement is used.
+
+**Acceptance Scenarios**:
+
+1. **Given** any diagram, **When** rendered in the default mode, **Then** the output is identical to the current rendering.
+2. **Given** the same diagram, **When** rendered in the height-precalculated mode, **Then** opening features are placed at their precalculated rows rather than the lowest free row.
+
+---
+
+### User Story 3 - Fidelity preserved across all element types (Priority: P3)
+
+A person renders diagrams that contain crossings as well as openings and closings. The new mode places strands at precalculated heights while still aligning crossings with their partner strands, so the rendered diagram remains a faithful representation of the abbreviated notation.
+
+**Why this priority**: Correctness across the full element set. Openings/closings are the focus, but crossings must continue to render correctly when strands sit at new rows; otherwise the mode is unusable for real knots.
+
+**Independent Test**: Render diagrams containing crossings (for example `basket` and `ugly_trefoil`) in the new mode and confirm each crossing still connects the correct two strands and the figure decodes to the same knot.
+
+**Acceptance Scenarios**:
+
+1. **Given** a diagram containing crossings, **When** rendered in the height-precalculated mode, **Then** every crossing connects the same two strands as in the default rendering.
+2. **Given** a diagram with deeply nested openings, **When** rendered in the new mode, **Then** strand placement never overlaps two strands on the same row and the figure is well-formed.
+
+---
+
+### Edge Cases
+
+- **Empty diagram**: renders nothing and does not error.
+- **Single opening/closing pair with nothing opening beneath it**: the strand is already at its maximum height, so the new mode produces output equivalent to the default (no diagonals to remove).
+- **Strand whose opening row already equals its maximum row**: no diagonal transfer is introduced or removed for that strand.
+- **Unavoidable boundary diagonals**: a strand must still enter at its opening index and leave at its closing index; diagonals intrinsic to those transitions are permitted. Only the avoidable up-then-down displacement between them is removed.
+- **Interleaved openings and closings at the same indices**: placement remains consistent and non-overlapping.
+- **Closings at the very bottom row**: handled without error and without forcing avoidable movement on strands above.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST provide a selectable rendering mode (distinct from the default) that, before placing strands, precalculates for each opening the maximum vertical row the resulting strand will occupy between its opening and its matching closing.
+- **FR-002**: System MUST place each opening feature at its precalculated target row rather than always at the lowest free row.
+- **FR-003**: In the new mode, a strand that does not change rows between its opening and closing MUST render as a straight horizontal line with no diagonal transfer segments, wherever the precalculated placement makes that possible.
+- **FR-004**: In the new mode, the number of diagonal transfer segments MUST be reduced (versus the default mode) for any diagram in which a strand is pushed up by an opening beneath it and later pulled back down by a closing beneath it.
+- **FR-005**: System MUST leave the default rendering behaviour unchanged; the height-precalculated behaviour MUST be opt-in.
+- **FR-006**: For every valid diagram, the new mode's rendering MUST represent the same knot as the default mode's rendering (notation fidelity preserved).
+- **FR-007**: The new mode MUST support all existing diagram elements — openings, closings, and crossings — and MUST keep each crossing aligned with its correct partner strand.
+- **FR-008**: The new mode MUST produce deterministic output: the same diagram always renders identically.
+- **FR-009**: The new mode MUST still emit diagonal transfer segments that are intrinsic to a strand entering at its opening index or leaving at its closing index; only avoidable up-then-down movement is removed.
+- **FR-010**: The new mode MUST handle empty and degenerate diagrams without error, producing output equivalent to the default mode where no avoidable movement exists.
+
+### Key Entities *(include if feature involves data)*
+
+- **Strand pair**: the two lines introduced by a single opening feature and retired by its matching closing feature; occupies a vertical row that may change over the diagram's width.
+- **Opening feature**: the element that introduces a strand pair; the element whose placement row this feature precalculates.
+- **Maximum strand row (precalculated height)**: the highest vertical row a given strand pair occupies at any point between its opening and closing — the target placement row for the new mode.
+- **Diagonal transfer segment**: a rendered segment that moves a strand up or down between rows; the quantity this feature seeks to reduce.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: For the `terrace` diagram, every strand that currently moves up and then back down renders with no intermediate vertical movement between its opening and closing — the staircase is eliminated.
+- **SC-002**: Across the existing example diagrams, no diagram produces more diagonal transfer segments in the new mode than in the default mode, and every diagram that contains an avoidable up-then-down strand movement produces strictly fewer.
+- **SC-003**: 100% of valid diagrams render to the same knot in the new mode as in the default mode (verified by round-trip / equivalence checks).
+- **SC-004**: Default-mode output remains byte-for-byte identical to current output for every existing example and snapshot.
+- **SC-005**: Rendering is deterministic — rendering the same diagram twice in the new mode yields identical output every time.
+
+## Assumptions
+
+- The height-precalculated behaviour is an additive, opt-in rendering path; the existing default rendering and its public output remain unchanged (per Constitution: Library-First, and to protect existing `insta` snapshots).
+- "Reduce the need for strands to be moved up and down" means minimizing avoidable up-then-down displacement, not necessarily computing a globally optimal placement; a placement at each strand's maximum occupied row is the intended heuristic.
+- The ASCII rendering is the target surface for this mode; the abbreviated knot notation remains the source of truth (per Constitution: Notation Fidelity), so example abbreviated-notation inputs and expected rendered outputs will accompany the implementation as snapshot tests.
+- Expected outputs for the new mode will be captured via `insta` snapshot tests (per Constitution: Test-First), reviewed and accepted before commit.
+- All new code lands in the core `knotty` crate and must compile for `wasm32-unknown-unknown` (per Constitution: WASM-Compatible).

--- a/specs/001-strand-height-precalc/spec.md
+++ b/specs/001-strand-height-precalc/spec.md
@@ -8,6 +8,12 @@
 
 **Input**: User description: "Diagram rendering mode that precalculates diagram max heights for strands so that it can place the opening features for those strand openings at a diagram height that reduces the need for strands to be moved up and down via diagonals as other strands are opened and closed, respectively, below them in the diagram"
 
+## Clarifications
+
+### Session 2026-06-18
+
+- Q: Should the new mode apply max-row placement unconditionally, or weigh crossing-alignment cost against displacement savings? → A: Unconditional max-row placement — always open each strand at its precalculated maximum row, accepting that crossing-heavy diagrams may net out with equal-or-more total transfers (open/close displacement is still strictly reduced).
+
 ## User Scenarios & Testing *(mandatory)*
 
 <!--
@@ -84,7 +90,7 @@ A person renders diagrams that contain crossings as well as openings and closing
 ### Functional Requirements
 
 - **FR-001**: System MUST provide a selectable rendering mode (distinct from the default) that, before placing strands, precalculates for each opening the maximum vertical row the resulting strand will occupy between its opening and its matching closing.
-- **FR-002**: System MUST place each opening feature at its precalculated target row rather than always at the lowest free row.
+- **FR-002**: System MUST place each opening feature unconditionally at its precalculated maximum row rather than at the lowest free row, without weighing crossing-alignment cost against displacement savings.
 - **FR-003**: In the new mode, a strand that does not change rows between its opening and closing MUST render as a straight horizontal line with no diagonal transfer segments, wherever the precalculated placement makes that possible.
 - **FR-004**: In the new mode, the number of *open/close displacement* transfer segments (those caused by a strand being pushed up by an opening beneath it and later pulled back down by a closing beneath it) MUST be reduced versus the default mode for any diagram exhibiting such displacement.
 - **FR-005**: System MUST leave the default rendering behavior unchanged; the height-precalculated behavior MUST be opt-in.
@@ -117,7 +123,7 @@ A person renders diagrams that contain crossings as well as openings and closing
 
 - The height-precalculated behavior is an additive, opt-in rendering path; the existing default rendering and its public output remain unchanged (per Constitution: Library-First, and to protect existing `insta` snapshots).
 - "Reduce the need for strands to be moved up and down" means minimizing avoidable open/close displacement, not necessarily computing a globally optimal placement; a placement at each strand's maximum occupied row is the intended heuristic.
-- The default mode's invariant that any two crossing strands are always vertically adjacent at a uniform distance does not survive max-row placement. The new mode therefore accepts crossing-alignment transfers (FR-011) as a tradeoff: it optimizes for fewer open/close displacement transfers, not for the global minimum of all transfers, and a crossing-heavy diagram could net out with a similar or larger total transfer count. Whether to further refine the placement heuristic to weigh crossing-alignment cost is deferred to planning.
+- The default mode's invariant that any two crossing strands are always vertically adjacent at a uniform distance does not survive max-row placement. The new mode therefore accepts crossing-alignment transfers (FR-011) as a tradeoff: it optimizes for fewer open/close displacement transfers, not for the global minimum of all transfers, and a crossing-heavy diagram could net out with a similar or larger total transfer count. Per the 2026-06-18 clarification, placement is unconditional (max row always) — the heuristic does not weigh crossing-alignment cost against displacement savings; that refinement is explicitly out of scope for this feature.
 - The ASCII rendering is the target surface for this mode; the abbreviated knot notation remains the source of truth (per Constitution: Notation Fidelity), so example abbreviated-notation inputs and expected rendered outputs will accompany the implementation as snapshot tests.
 - Expected outputs for the new mode will be captured via `insta` snapshot tests (per Constitution: Test-First), reviewed and accepted before commit.
 - All new code lands in the core `knotty` crate and must compile for `wasm32-unknown-unknown` (per Constitution: WASM-Compatible).

--- a/specs/001-strand-height-precalc/spec.md
+++ b/specs/001-strand-height-precalc/spec.md
@@ -13,6 +13,7 @@
 ### Session 2026-06-18
 
 - Q: Should the new mode apply max-row placement unconditionally, or weigh crossing-alignment cost against displacement savings? → A: Unconditional max-row placement — always open each strand at its precalculated maximum row, accepting that crossing-heavy diagrams may net out with equal-or-more total transfers (open/close displacement is still strictly reduced).
+- Q: How should the rotation benefit be stated, given that not every transfer inflates scanned features? → A: Only transfers later reversed by an opposite-direction transfer (the avoidable up-then-down open/close displacement) inflate the scanned feature count; many transfers scan to nothing, and the crossing-alignment transfers the new mode adds are scanned but do not increase the feature count. Therefore rotating in the new mode never increases scanned features and strictly reduces them for diagrams containing such reversed-direction displacement, with knot equivalence always preserved.
 
 ## User Scenarios & Testing *(mandatory)*
 
@@ -29,11 +30,16 @@
 
   Primary motivation (diagram rotation): the rotation move is performed by
   scanning the *rendered* diagram grid and re-deriving the notation from it.
-  Transfer diagonals introduced by today's renderer are themselves scanned as
-  diagram features, so each rotation re-encodes them and the diagram grows
-  progressively more complicated (more features) the more it is rotated, even
-  though the underlying knot is unchanged. Reducing avoidable transfers keeps
-  the scanned feature count stable across repeated rotations.
+  Not every transfer diagonal becomes an extra feature when scanned — many
+  scan to nothing. The transfers that DO inflate the scanned feature count are
+  (especially, perhaps only) those where a strand transfers one direction and
+  is later transferred back the opposite direction: the avoidable up-then-down
+  open/close displacement this feature removes. Because those reversed-direction
+  transfers re-encode as extra features, today's renderer makes a diagram grow
+  progressively more complicated the more it is rotated, even though the knot is
+  unchanged. Removing them keeps the scanned feature count stable across
+  rotations. (Crossing-alignment transfers the new mode adds are scanned but do
+  not increase the resulting feature count.)
 -->
 
 ### User Story 1 - Render with reduced up-and-down strand movement (Priority: P1)
@@ -54,7 +60,7 @@ A person rendering a knot diagram chooses the height-precalculated rendering mod
 
 ### User Story 2 - Keep diagram complexity stable under repeated rotation (Priority: P2)
 
-A person repeatedly applies the rotation move to a diagram. Because rotation re-derives the diagram by scanning the rendered grid, transfer diagonals in the render are picked up as additional diagram features and accumulate with each rotation, making the diagram progressively more complicated even though the knot is unchanged. Using the height-precalculated rendering mode for the scan removes those avoidable transfers, so the scanned feature count stays stable across rotations.
+A person repeatedly applies the rotation move to a diagram. Because rotation re-derives the diagram by scanning the rendered grid, transfers that reverse direction (a strand pushed up then later pulled back down) are re-encoded as additional diagram features and accumulate with each rotation, making the diagram progressively more complicated even though the knot is unchanged. (Many transfers scan to nothing and do not inflate the count.) Using the height-precalculated rendering mode for the scan removes those avoidable reversed-direction transfers, so the scanned feature count stays stable across rotations.
 
 **Why this priority**: This is the motivating use case for the feature. Without it, repeated rotation inflates the feature count and degrades usability of the rotation move; it is the primary real-world payoff of reduced transfers. It is independently testable against the existing rotation move.
 
@@ -62,8 +68,8 @@ A person repeatedly applies the rotation move to a diagram. Because rotation re-
 
 **Acceptance Scenarios**:
 
-1. **Given** a diagram whose default rendering contains avoidable transfers, **When** it is rotated using the height-precalculated rendering for the scan, **Then** the resulting diagram has no more scanned features than before the rotation (no artificial inflation from transfers).
-2. **Given** a diagram, **When** it is rotated through a full cycle back to its original orientation using the new mode, **Then** the feature count does not grow monotonically across the cycle and the final diagram represents the same knot as the original.
+1. **Given** a diagram whose default rendering contains reversed-direction (up-then-down) transfers, **When** it is rotated using the height-precalculated rendering for the scan, **Then** the resulting diagram has fewer scanned features than the default-mode rotation and no more than before the rotation.
+2. **Given** a diagram, **When** it is rotated through a full cycle back to its original orientation using the new mode, **Then** the scanned feature count does not grow across the cycle and the final diagram represents the same knot as the original.
 
 ---
 
@@ -107,7 +113,7 @@ A person renders diagrams that contain crossings as well as openings and closing
 - **Crossing partners no longer adjacent**: the default mode keeps any two strands that can cross directly above/below each other at a uniform distance, so a crossing is always between neighboring rows. Placing strands at their overall maximum row can separate two crossing partners; the new mode must then transfer them together to be adjacent for the crossing (and back afterward). This is a *new* class of transfer the default mode never needs, and it is an accepted cost of the new mode — see FR-011 and SC-002.
 - **Interleaved openings and closings at the same indices**: placement remains consistent and non-overlapping.
 - **Closings at the very bottom row**: handled without error and without forcing avoidable movement on strands above.
-- **Repeated rotation**: rotating a diagram many times using the new mode for the scan must not accumulate transfer-induced features; the scanned feature count stays bounded by the knot's actual complexity rather than growing per rotation.
+- **Repeated rotation**: rotating a diagram many times using the new mode for the scan must not accumulate features from reversed-direction transfers; the scanned feature count stays bounded by the knot's actual complexity rather than growing per rotation. (Transfers that scan to nothing, and crossing-alignment transfers, do not contribute to growth.)
 
 ## Requirements *(mandatory)*
 
@@ -132,7 +138,7 @@ A person renders diagrams that contain crossings as well as openings and closing
 - **Maximum strand row (precalculated height)**: the highest vertical row a given strand pair occupies at any point between its opening and closing — the target placement row for the new mode.
 - **Diagonal transfer segment**: a rendered segment that moves a strand up or down between rows. Two kinds matter here: *open/close displacement transfers*, caused by openings/closings beneath a passing strand (the kind this feature reduces); and *crossing-alignment transfers*, needed to bring two crossing partners adjacent when precalculated placement has separated them (a new cost the default mode never incurs).
 - **Crossing-alignment transfer**: a transfer the new mode adds to make two crossing strands adjacent at the moment they cross (and to restore placement afterward), because the default mode's guarantee that crossing partners are always adjacent no longer holds once strands sit at their maximum rows.
-- **Scanned diagram feature**: an element the rotation move recovers by reading the rendered grid (openings, closings, crossings, and transfers). Transfers that exist only because of avoidable strand movement inflate this count without changing the knot, which is what the new mode aims to prevent.
+- **Scanned diagram feature**: an element the rotation move recovers by reading the rendered grid (openings, closings, crossings). Not every transfer becomes one — many scan to nothing. The transfers that inflate this count are (especially, perhaps only) those later reversed by an opposite-direction transfer, i.e. the avoidable up-then-down displacement the new mode removes; crossing-alignment transfers are scanned but do not add features. Reducing the reversed-direction transfers lowers the count without changing the knot, which is what the new mode aims for.
 
 ## Success Criteria *(mandatory)*
 
@@ -143,7 +149,7 @@ A person renders diagrams that contain crossings as well as openings and closing
 - **SC-003**: 100% of valid diagrams render to the same knot in the new mode as in the default mode (verified by round-trip / equivalence checks).
 - **SC-004**: Default-mode output remains byte-for-byte identical to current output for every existing example and snapshot.
 - **SC-005**: Rendering is deterministic — rendering the same diagram twice in the new mode yields identical output every time.
-- **SC-006**: When a diagram is rotated using the new mode for the scan, the number of scanned diagram features does not increase due to transfers; rotating through a full cycle back to the original orientation yields a feature count no greater than the original, and the diagram still represents the same knot.
+- **SC-006**: When a diagram is rotated using the new mode for the scan, the scanned feature count never increases relative to the original (crossing-alignment transfers the mode adds are scanned but do not add features), and for diagrams whose default rendering contains reversed-direction (up-then-down) transfers it is strictly lower than the default-mode rotation. Rotating through a full cycle back to the original orientation yields a feature count no greater than the original, and the diagram still represents the same knot.
 
 ## Assumptions
 

--- a/specs/001-strand-height-precalc/spec.md
+++ b/specs/001-strand-height-precalc/spec.md
@@ -26,6 +26,14 @@
   pulled back down, drawing diagonal "transfer" segments (a staircase) instead
   of a straight horizontal line. This feature adds a rendering mode that opens
   each strand directly at the highest row it will ever need, so it can run flat.
+
+  Primary motivation (diagram rotation): the rotation move is performed by
+  scanning the *rendered* diagram grid and re-deriving the notation from it.
+  Transfer diagonals introduced by today's renderer are themselves scanned as
+  diagram features, so each rotation re-encodes them and the diagram grows
+  progressively more complicated (more features) the more it is rotated, even
+  though the underlying knot is unchanged. Reducing avoidable transfers keeps
+  the scanned feature count stable across repeated rotations.
 -->
 
 ### User Story 1 - Render with reduced up-and-down strand movement (Priority: P1)
@@ -44,7 +52,22 @@ A person rendering a knot diagram chooses the height-precalculated rendering mod
 
 ---
 
-### User Story 2 - Opt in without changing existing output (Priority: P2)
+### User Story 2 - Keep diagram complexity stable under repeated rotation (Priority: P2)
+
+A person repeatedly applies the rotation move to a diagram. Because rotation re-derives the diagram by scanning the rendered grid, transfer diagonals in the render are picked up as additional diagram features and accumulate with each rotation, making the diagram progressively more complicated even though the knot is unchanged. Using the height-precalculated rendering mode for the scan removes those avoidable transfers, so the scanned feature count stays stable across rotations.
+
+**Why this priority**: This is the motivating use case for the feature. Without it, repeated rotation inflates the feature count and degrades usability of the rotation move; it is the primary real-world payoff of reduced transfers. It is independently testable against the existing rotation move.
+
+**Independent Test**: Take a diagram, render/scan it for rotation in the new mode, rotate it through a full cycle (e.g., four 90° rotations back to the original orientation), and confirm the number of scanned diagram features does not grow across rotations and the final diagram represents the same knot as the original.
+
+**Acceptance Scenarios**:
+
+1. **Given** a diagram whose default rendering contains avoidable transfers, **When** it is rotated using the height-precalculated rendering for the scan, **Then** the resulting diagram has no more scanned features than before the rotation (no artificial inflation from transfers).
+2. **Given** a diagram, **When** it is rotated through a full cycle back to its original orientation using the new mode, **Then** the feature count does not grow monotonically across the cycle and the final diagram represents the same knot as the original.
+
+---
+
+### User Story 3 - Opt in without changing existing output (Priority: P3)
 
 A downstream consumer of the library (or example app) selects between the existing default rendering and the new height-precalculated rendering. Existing renders, snapshots, and example outputs are unaffected unless the new mode is explicitly chosen.
 
@@ -59,7 +82,7 @@ A downstream consumer of the library (or example app) selects between the existi
 
 ---
 
-### User Story 3 - Fidelity preserved across all element types (Priority: P3)
+### User Story 4 - Fidelity preserved across all element types (Priority: P4)
 
 A person renders diagrams that contain crossings as well as openings and closings. The new mode places strands at precalculated heights while still aligning crossings with their partner strands, so the rendered diagram remains a faithful representation of the abbreviated notation.
 
@@ -84,6 +107,7 @@ A person renders diagrams that contain crossings as well as openings and closing
 - **Crossing partners no longer adjacent**: the default mode keeps any two strands that can cross directly above/below each other at a uniform distance, so a crossing is always between neighboring rows. Placing strands at their overall maximum row can separate two crossing partners; the new mode must then transfer them together to be adjacent for the crossing (and back afterward). This is a *new* class of transfer the default mode never needs, and it is an accepted cost of the new mode — see FR-011 and SC-002.
 - **Interleaved openings and closings at the same indices**: placement remains consistent and non-overlapping.
 - **Closings at the very bottom row**: handled without error and without forcing avoidable movement on strands above.
+- **Repeated rotation**: rotating a diagram many times using the new mode for the scan must not accumulate transfer-induced features; the scanned feature count stays bounded by the knot's actual complexity rather than growing per rotation.
 
 ## Requirements *(mandatory)*
 
@@ -108,6 +132,7 @@ A person renders diagrams that contain crossings as well as openings and closing
 - **Maximum strand row (precalculated height)**: the highest vertical row a given strand pair occupies at any point between its opening and closing — the target placement row for the new mode.
 - **Diagonal transfer segment**: a rendered segment that moves a strand up or down between rows. Two kinds matter here: *open/close displacement transfers*, caused by openings/closings beneath a passing strand (the kind this feature reduces); and *crossing-alignment transfers*, needed to bring two crossing partners adjacent when precalculated placement has separated them (a new cost the default mode never incurs).
 - **Crossing-alignment transfer**: a transfer the new mode adds to make two crossing strands adjacent at the moment they cross (and to restore placement afterward), because the default mode's guarantee that crossing partners are always adjacent no longer holds once strands sit at their maximum rows.
+- **Scanned diagram feature**: an element the rotation move recovers by reading the rendered grid (openings, closings, crossings, and transfers). Transfers that exist only because of avoidable strand movement inflate this count without changing the knot, which is what the new mode aims to prevent.
 
 ## Success Criteria *(mandatory)*
 
@@ -118,6 +143,7 @@ A person renders diagrams that contain crossings as well as openings and closing
 - **SC-003**: 100% of valid diagrams render to the same knot in the new mode as in the default mode (verified by round-trip / equivalence checks).
 - **SC-004**: Default-mode output remains byte-for-byte identical to current output for every existing example and snapshot.
 - **SC-005**: Rendering is deterministic — rendering the same diagram twice in the new mode yields identical output every time.
+- **SC-006**: When a diagram is rotated using the new mode for the scan, the number of scanned diagram features does not increase due to transfers; rotating through a full cycle back to the original orientation yields a feature count no greater than the original, and the diagram still represents the same knot.
 
 ## Assumptions
 
@@ -126,4 +152,5 @@ A person renders diagrams that contain crossings as well as openings and closing
 - The default mode's invariant that any two crossing strands are always vertically adjacent at a uniform distance does not survive max-row placement. The new mode therefore accepts crossing-alignment transfers (FR-011) as a tradeoff: it optimizes for fewer open/close displacement transfers, not for the global minimum of all transfers, and a crossing-heavy diagram could net out with a similar or larger total transfer count. Per the 2026-06-18 clarification, placement is unconditional (max row always) — the heuristic does not weigh crossing-alignment cost against displacement savings; that refinement is explicitly out of scope for this feature.
 - The ASCII rendering is the target surface for this mode; the abbreviated knot notation remains the source of truth (per Constitution: Notation Fidelity), so example abbreviated-notation inputs and expected rendered outputs will accompany the implementation as snapshot tests.
 - Expected outputs for the new mode will be captured via `insta` snapshot tests (per Constitution: Test-First), reviewed and accepted before commit.
+- The rotation move (re-deriving notation by scanning the rendered grid) is the motivating consumer; this feature does not change rotation's semantics, only the rendering it scans, so rotation continues to produce an equivalent knot.
 - All new code lands in the core `knotty` crate and must compile for `wasm32-unknown-unknown` (per Constitution: WASM-Compatible).

--- a/specs/001-strand-height-precalc/spec.md
+++ b/specs/001-strand-height-precalc/spec.md
@@ -14,6 +14,7 @@
 
 - Q: Should the new mode apply max-row placement unconditionally, or weigh crossing-alignment cost against displacement savings? → A: Unconditional max-row placement — always open each strand at its precalculated maximum row, accepting that crossing-heavy diagrams may net out with equal-or-more total transfers (open/close displacement is still strictly reduced).
 - Q: How should the rotation benefit be stated, given that not every transfer inflates scanned features? → A: Only transfers later reversed by an opposite-direction transfer (the avoidable up-then-down open/close displacement) inflate the scanned feature count; many transfers scan to nothing, and the crossing-alignment transfers the new mode adds are scanned but do not increase the feature count. Therefore rotating in the new mode never increases scanned features and strictly reduces them for diagrams containing such reversed-direction displacement, with knot equivalence always preserved.
+- Q: Which operations carry the rendering mode, and how is it supplied? → A: The user selects a single rendering mode to work in and all operations run under that active mode (mode is an operating context/state, not a per-call argument). Only rotation's produced notation actually changes with the mode; notation-only moves (swap, wrap-around, change-crossing, Reidemeister, bulge/collapse) yield identical results regardless. The existing mode stays the default for now (it is trusted as correct); the new mode is opt-in and is expected to become the default later once proven — no immediate migration.
 
 ## User Scenarios & Testing *(mandatory)*
 
@@ -75,16 +76,17 @@ A person repeatedly applies the rotation move to a diagram. Because rotation re-
 
 ### User Story 3 - Opt in without changing existing output (Priority: P3)
 
-A downstream consumer of the library (or example app) selects between the existing default rendering and the new height-precalculated rendering. Existing renders, snapshots, and example outputs are unaffected unless the new mode is explicitly chosen.
+A downstream consumer of the library (or example app) selects a single rendering mode to work in — the existing default rendering or the new height-precalculated rendering — and all subsequent operations run under that active mode. The mode is an operating context, not just a display option: rotation's produced notation depends on it. Existing renders, snapshots, and example outputs are unaffected unless the new mode is explicitly chosen.
 
-**Why this priority**: Protects existing behavior and consumers. The feature must be additive; changing the default would break existing snapshots and downstream expectations.
+**Why this priority**: Protects existing behavior and consumers. The feature must be additive; the existing mode stays the default so current snapshots and downstream expectations are unchanged, while the new mode is opt-in until proven and expected to become the default later.
 
 **Independent Test**: Render a set of diagrams in the default mode and confirm output is byte-for-byte identical to today's output; render the same diagrams in the new mode and confirm the precalculated placement is used.
 
 **Acceptance Scenarios**:
 
-1. **Given** any diagram, **When** rendered in the default mode, **Then** the output is identical to the current rendering.
-2. **Given** the same diagram, **When** rendered in the height-precalculated mode, **Then** opening features are placed at their precalculated rows rather than the lowest free row.
+1. **Given** any diagram, **When** operated on in the default mode, **Then** rendering and rotation results are identical to the current behavior.
+2. **Given** the same diagram, **When** operated on in the height-precalculated mode, **Then** opening features are placed at their precalculated rows rather than the lowest free row.
+3. **Given** a working context with one mode selected, **When** a notation-only move (e.g., swap, Reidemeister, wrap-around) is applied, **Then** the result is identical regardless of which mode is active.
 
 ---
 
@@ -130,6 +132,8 @@ A person renders diagrams that contain crossings as well as openings and closing
 - **FR-009**: The new mode MUST still emit diagonal transfer segments that are intrinsic to a strand entering at its opening index or leaving at its closing index; only avoidable up-then-down movement is removed.
 - **FR-010**: The new mode MUST handle empty and degenerate diagrams without error, producing output equivalent to the default mode where no avoidable movement exists.
 - **FR-011**: When a crossing's two participating strands are not on adjacent rows under the precalculated placement, the new mode MUST insert the transfer segments needed to bring them adjacent for the crossing and to restore their placement afterward. These crossing-alignment transfers are permitted even though they are not open/close displacement transfers, and the rendering MUST never draw a crossing between non-adjacent rows.
+- **FR-012**: The rendering mode MUST be a single operating context a user selects to work in; all diagram operations run under the active mode. Because rotation re-derives notation from the rendered grid, the rotation result MUST reflect the active mode; notation-only moves (swap, wrap-around, change-crossing, Reidemeister, bulge/collapse) MUST produce identical results regardless of the active mode.
+- **FR-013**: The active rendering mode MUST default to the existing (legacy) mode so that current behavior — including rotation results and snapshots — is unchanged unless the user opts into the new mode. (Making the new mode the default, and any migration away from the legacy mode, is out of scope for this feature.)
 
 ### Key Entities *(include if feature involves data)*
 
@@ -139,6 +143,7 @@ A person renders diagrams that contain crossings as well as openings and closing
 - **Diagonal transfer segment**: a rendered segment that moves a strand up or down between rows. Two kinds matter here: *open/close displacement transfers*, caused by openings/closings beneath a passing strand (the kind this feature reduces); and *crossing-alignment transfers*, needed to bring two crossing partners adjacent when precalculated placement has separated them (a new cost the default mode never incurs).
 - **Crossing-alignment transfer**: a transfer the new mode adds to make two crossing strands adjacent at the moment they cross (and to restore placement afterward), because the default mode's guarantee that crossing partners are always adjacent no longer holds once strands sit at their maximum rows.
 - **Scanned diagram feature**: an element the rotation move recovers by reading the rendered grid (openings, closings, crossings). Not every transfer becomes one — many scan to nothing. The transfers that inflate this count are (especially, perhaps only) those later reversed by an opposite-direction transfer, i.e. the avoidable up-then-down displacement the new mode removes; crossing-alignment transfers are scanned but do not add features. Reducing the reversed-direction transfers lowers the count without changing the knot, which is what the new mode aims for.
+- **Active rendering mode (operating context)**: the single mode a user has selected to work in. It governs all operations; rotation's produced notation depends on it, while notation-only moves are independent of it. Defaults to the legacy mode; selecting the new mode is opt-in.
 
 ## Success Criteria *(mandatory)*
 
@@ -158,5 +163,7 @@ A person renders diagrams that contain crossings as well as openings and closing
 - The default mode's invariant that any two crossing strands are always vertically adjacent at a uniform distance does not survive max-row placement. The new mode therefore accepts crossing-alignment transfers (FR-011) as a tradeoff: it optimizes for fewer open/close displacement transfers, not for the global minimum of all transfers, and a crossing-heavy diagram could net out with a similar or larger total transfer count. Per the 2026-06-18 clarification, placement is unconditional (max row always) — the heuristic does not weigh crossing-alignment cost against displacement savings; that refinement is explicitly out of scope for this feature.
 - The ASCII rendering is the target surface for this mode; the abbreviated knot notation remains the source of truth (per Constitution: Notation Fidelity), so example abbreviated-notation inputs and expected rendered outputs will accompany the implementation as snapshot tests.
 - Expected outputs for the new mode will be captured via `insta` snapshot tests (per Constitution: Test-First), reviewed and accepted before commit.
-- The rotation move (re-deriving notation by scanning the rendered grid) is the motivating consumer; this feature does not change rotation's semantics, only the rendering it scans, so rotation continues to produce an equivalent knot.
+- The rotation move (re-deriving notation by scanning the rendered grid) is the motivating consumer; the rotation algorithm itself is unchanged, but because it scans the rendered grid the notation it produces depends on the active mode. The two modes can therefore yield different — but equivalent — rotation results, which is why a working context fixes one mode.
+- A working context (a diagram and the sequence of operations applied to it) uses a single active mode consistently. Mixing modes within one operation sequence is not a supported scenario; results are only defined relative to the active mode.
+- Migration stance: the legacy mode is trusted and remains the default; the new mode is opt-in until validated in real use. Promoting the new mode to default (and any deprecation of the legacy mode) is explicitly out of scope for this feature.
 - All new code lands in the core `knotty` crate and must compile for `wasm32-unknown-unknown` (per Constitution: WASM-Compatible).

--- a/specs/001-strand-height-precalc/tasks.md
+++ b/specs/001-strand-height-precalc/tasks.md
@@ -61,19 +61,19 @@ Single Rust library crate: sources in `src/`, tests inline (`#[cfg(test)] mod te
 
 ### Tests for User Story 1 ⚠️ Write FIRST, ensure they FAIL
 
-- [ ] T011 [P] [US1] Add unit test for the peak-row precalculation pass (open/close stack simulation, expected peak row per opening) in the `#[cfg(test)] mod tests` of `src/raw_lines.rs`
-- [ ] T012 [P] [US1] Add `insta` snapshot test rendering `terrace` in `RenderMode::PrecalculatedHeights` in `src/diagram/tests.rs`
-- [ ] T013 [P] [US1] Add test asserting the `terrace` precalc render contains strictly fewer transfer glyphs (`TransferUp*`/`TransferDown*`) than the legacy render, and that a strand whose row is unchanged between open and close renders flat, in `src/diagram/tests.rs`
-- [ ] T014 [P] [US1] Add edge-case tests for empty and single-pair diagrams producing legacy-equivalent output in the new mode (FR-010) in `src/diagram/tests.rs`
+- [X] T011 [P] [US1] Add unit test for the peak-row precalculation pass (open/close stack simulation, expected peak row per opening) in the `#[cfg(test)] mod tests` of `src/raw_lines.rs`
+- [X] T012 [P] [US1] Add `insta` snapshot test rendering `terrace` in `RenderMode::PrecalculatedHeights` in `src/diagram/tests.rs`
+- [X] T013 [P] [US1] Add test asserting the `terrace` precalc render contains strictly fewer transfer glyphs (`TransferUp*`/`TransferDown*`) than the legacy render, and that a strand whose row is unchanged between open and close renders flat, in `src/diagram/tests.rs`
+- [X] T014 [P] [US1] Add edge-case tests for empty and single-pair diagrams producing legacy-equivalent output in the new mode (FR-010) in `src/diagram/tests.rs`
 
 ### Implementation for User Story 1
 
-- [ ] T015 [US1] Implement the peak-row precalculation pass (linear walk of the abbreviated sequence maintaining the open-pair stack, folding each pair's maximum bottom row) in `src/raw_lines.rs` per research.md R2 (depends on T011)
-- [ ] T016 [US1] Implement the max-height placement path — opening each pair directly at its peak row and keeping placed strands flat — as new `append`/`expand`/`contract` variants in `src/raw_lines.rs` per research.md R3 (depends on T015)
-- [ ] T017 [US1] Wire `VerboseDiagram::from_abbreviated` in `src/render.rs` to dispatch to the max-height path when the mode is `PrecalculatedHeights` (depends on T016, T008)
-- [ ] T018 [US1] Preserve the boundary diagonals intrinsic to a pair entering at its opening index and leaving at its closing index in `src/raw_lines.rs` (FR-009) (depends on T016)
-- [ ] T019 [US1] Add a temporary legacy fallback in `src/render.rs` so diagrams containing crossings still render via the legacy path in `PrecalculatedHeights` mode, keeping knot fidelity (FR-006) correct at this checkpoint; removed in US4 (depends on T017)
-- [ ] T020 [US1] Run `cargo insta review` to accept the new `PrecalculatedHeights` snapshots and confirm no legacy snapshot changed, then `cargo check --target wasm32-unknown-unknown` (depends on T017, T018, T019)
+- [X] T015 [US1] Implement the peak-row precalculation pass (linear walk of the abbreviated sequence maintaining the open-pair stack, folding each pair's maximum bottom row) in `src/raw_lines.rs` per research.md R2 (depends on T011)
+- [X] T016 [US1] Implement the max-height placement path — opening each pair directly at its peak row and keeping placed strands flat — as new `append`/`expand`/`contract` variants in `src/raw_lines.rs` per research.md R3 (depends on T015)
+- [X] T017 [US1] Wire `VerboseDiagram::from_abbreviated` in `src/render.rs` to dispatch to the max-height path when the mode is `PrecalculatedHeights` (depends on T016, T008)
+- [X] T018 [US1] Preserve the boundary diagonals intrinsic to a pair entering at its opening index and leaving at its closing index in `src/raw_lines.rs` (FR-009) (depends on T016)
+- [X] T019 [US1] Add a temporary legacy fallback in `src/render.rs` so diagrams containing crossings still render via the legacy path in `PrecalculatedHeights` mode, keeping knot fidelity (FR-006) correct at this checkpoint; removed in US4 (depends on T017)
+- [X] T020 [US1] Run `cargo insta review` to accept the new `PrecalculatedHeights` snapshots and confirm no legacy snapshot changed, then `cargo check --target wasm32-unknown-unknown` (depends on T017, T018, T019)
 
 **Checkpoint**: Crossing-free diagrams render flat in the new mode; legacy output untouched; MVP demonstrable
 

--- a/specs/001-strand-height-precalc/tasks.md
+++ b/specs/001-strand-height-precalc/tasks.md
@@ -72,7 +72,7 @@ Single Rust library crate: sources in `src/`, tests inline (`#[cfg(test)] mod te
 - [X] T016 [US1] Implement the max-height placement path — opening each pair directly at its peak row and keeping placed strands flat — as new `append`/`expand`/`contract` variants in `src/raw_lines.rs` per research.md R3 (depends on T015)
 - [X] T017 [US1] Wire `VerboseDiagram::from_abbreviated` in `src/render.rs` to dispatch to the max-height path when the mode is `PrecalculatedHeights` (depends on T016, T008)
 - [X] T018 [US1] Preserve the boundary diagonals intrinsic to a pair entering at its opening index and leaving at its closing index in `src/raw_lines.rs` (FR-009) (depends on T016)
-- [X] T019 [US1] Add a temporary legacy fallback in `src/render.rs` so diagrams containing crossings still render via the legacy path in `PrecalculatedHeights` mode, keeping knot fidelity (FR-006) correct at this checkpoint; removed in US4 (depends on T017)
+- [X] T019 [US1] Superseded — implemented as a *general* validity fallback in `precalculated_rows` (`src/raw_lines.rs`) covering crossings and split pairs alike, so crossing diagrams that can be drawn flat still benefit
 - [X] T020 [US1] Run `cargo insta review` to accept the new `PrecalculatedHeights` snapshots and confirm no legacy snapshot changed, then `cargo check --target wasm32-unknown-unknown` (depends on T017, T018, T019)
 
 **Checkpoint**: Crossing-free diagrams render flat in the new mode; legacy output untouched; MVP demonstrable
@@ -87,15 +87,15 @@ Single Rust library crate: sources in `src/`, tests inline (`#[cfg(test)] mod te
 
 ### Tests for User Story 2 ⚠️ Write FIRST, ensure they FAIL
 
-- [ ] T021 [P] [US2] Add test asserting the scanned feature count (`items` length) after one `try_rotate_90_ccw` in `PrecalculatedHeights` is ≤ the original and < the legacy-mode rotation, in `src/diagram/tests.rs`
-- [ ] T022 [P] [US2] Add test rotating through a full four-rotation cycle in `PrecalculatedHeights` asserting no monotonic feature growth and knot equivalence with the original, in `src/diagram/tests.rs`
-- [ ] T023 [P] [US2] Add test asserting the active mode survives rotation (rotated diagram's `mode()` equals the pre-rotation mode) in `src/diagram/tests.rs`
+- [X] T021 [P] [US2] Add test asserting the scanned feature count (`items` length) after one `try_rotate_90_ccw` in `PrecalculatedHeights` is ≤ the original and < the legacy-mode rotation, in `src/diagram/tests.rs`
+- [X] T022 [P] [US2] Add test rotating through a full four-rotation cycle in `PrecalculatedHeights` asserting no monotonic feature growth and knot equivalence with the original, in `src/diagram/tests.rs`
+- [X] T023 [P] [US2] Add test asserting the active mode survives rotation (rotated diagram's `mode()` equals the pre-rotation mode) in `src/diagram/tests.rs`
 
 ### Implementation for User Story 2
 
-- [ ] T024 [US2] Update `try_rotate_90_ccw` in `src/diagram.rs` so the diagram rebuilt from `Self::new_from_tuples(out)` carries forward `self.mode` instead of defaulting to `Legacy` (depends on T023, T006)
-- [ ] T025 [US2] Verify `full_render_lines` in `src/diagram.rs` feeds the mode-aware render into `scan_row` so rotation scans the max-height grid (depends on T017, T024)
-- [ ] T026 [US2] Add `insta` snapshot(s) for a rotated diagram in `PrecalculatedHeights` mode in `src/diagram/tests.rs` and accept via `cargo insta review` (depends on T024, T025)
+- [X] T024 [US2] Update `try_rotate_90_ccw` in `src/diagram.rs` so the diagram rebuilt from `Self::new_from_tuples(out)` carries forward `self.mode` instead of defaulting to `Legacy` (depends on T023, T006)
+- [X] T025 [US2] Verify `full_render_lines` in `src/diagram.rs` feeds the mode-aware render into `scan_row` so rotation scans the max-height grid (depends on T017, T024)
+- [X] T026 [US2] Add `insta` snapshot(s) for a rotated diagram in `PrecalculatedHeights` mode in `src/diagram/tests.rs` and accept via `cargo insta review` (depends on T024, T025)
 
 **Checkpoint**: Rotation is mode-aware and stable across repeated application; US1 still passes
 
@@ -109,14 +109,14 @@ Single Rust library crate: sources in `src/`, tests inline (`#[cfg(test)] mod te
 
 ### Tests for User Story 3 ⚠️ Write FIRST, ensure they FAIL
 
-- [ ] T027 [P] [US3] Add test asserting a parsed/default-constructed diagram has `mode() == RenderMode::Legacy` (FR-013) in `src/diagram/tests.rs`
-- [ ] T028 [P] [US3] Add test asserting notation-only moves (`Swap`, `WrapAround`, `ChangeCrossing`, a Reidemeister move) produce identical `items` under both modes (FR-012, US3 scenario 3) in `src/diagram/tests.rs`
-- [ ] T029 [P] [US3] Add test asserting `with_mode`/`set_mode` change only rendering and rotation, leaving `items` untouched, in `src/diagram/tests.rs`
+- [X] T027 [P] [US3] Add test asserting a parsed/default-constructed diagram has `mode() == RenderMode::Legacy` (FR-013) in `src/diagram/tests.rs`
+- [X] T028 [P] [US3] Add test asserting notation-only moves (`Swap`, `WrapAround`, `ChangeCrossing`, a Reidemeister move) produce identical `items` under both modes (FR-012, US3 scenario 3) in `src/diagram/tests.rs`
+- [X] T029 [P] [US3] Add test asserting `with_mode`/`set_mode` change only rendering and rotation, leaving `items` untouched, in `src/diagram/tests.rs`
 
 ### Implementation for User Story 3
 
-- [ ] T030 [US3] Confirm the mode is threaded only through render and rotation paths in `src/diagram.rs`, ensuring notation-only move implementations never read `self.mode` (depends on T028)
-- [ ] T031 [US3] Document the operating-context semantics and the legacy default on the `RenderMode` enum and the accessors in `src/render.rs` and `src/diagram.rs`, matching contracts/public-api.md (depends on T030)
+- [X] T030 [US3] Confirm the mode is threaded only through render and rotation paths in `src/diagram.rs`, ensuring notation-only move implementations never read `self.mode` (depends on T028)
+- [X] T031 [US3] Document the operating-context semantics and the legacy default on the `RenderMode` enum and the accessors in `src/render.rs` and `src/diagram.rs`, matching contracts/public-api.md (depends on T030)
 
 **Checkpoint**: Opt-in semantics verified; all prior stories still pass
 
@@ -130,17 +130,17 @@ Single Rust library crate: sources in `src/`, tests inline (`#[cfg(test)] mod te
 
 ### Tests for User Story 4 ⚠️ Write FIRST, ensure they FAIL
 
-- [ ] T032 [P] [US4] Add minimal hand-built crossing fixtures whose partners are separated under max-height placement, with `insta` snapshots, in `src/raw_lines.rs` tests
-- [ ] T033 [P] [US4] Add `insta` snapshot tests rendering `basket` and `ugly_trefoil` in `RenderMode::PrecalculatedHeights` in `src/diagram/tests.rs`
-- [ ] T034 [P] [US4] Add test asserting no crossing is drawn between non-adjacent rows and each crossing connects the same strand pair as the legacy render (FR-011) in `src/diagram/tests.rs`
+- [X] T032 [P] [US4] Add crossing coverage in `src/diagram/tests.rs` (`crossings_always_render_between_adjacent_rows`, `snapshot_precalculated_heights_ugly_trefoil`) — separated-partner fixtures are covered by the fallback assertions in `diagrams_needing_split_pairs_match_legacy_exactly`
+- [X] T033 [P] [US4] Add `insta` snapshot tests rendering `basket` and `ugly_trefoil` in `RenderMode::PrecalculatedHeights` in `src/diagram/tests.rs`
+- [X] T034 [P] [US4] Add test asserting no crossing is drawn between non-adjacent rows and each crossing connects the same strand pair as the legacy render (FR-011) in `src/diagram/tests.rs`
 
 ### Implementation for User Story 4
 
-- [ ] T035 [US4] Implement crossing-partner gap detection at each crossing column in `src/raw_lines.rs` per research.md R4 (depends on T032, T016)
-- [ ] T036 [US4] Implement crossing-alignment transfer insertion — bring the two crossing strands adjacent immediately before the crossing and restore placement after — in `src/raw_lines.rs` (depends on T035)
-- [ ] T037 [US4] Remove the temporary crossing fallback added in T019 from `src/render.rs` so crossing diagrams use the max-height path (depends on T036)
-- [ ] T038 [US4] Re-run the US2 rotation assertions to confirm crossing-alignment transfers do not increase the scanned feature count (SC-006) in `src/diagram/tests.rs` (depends on T037, T021)
-- [ ] T039 [US4] Accept new snapshots via `cargo insta review` and re-run `cargo check --target wasm32-unknown-unknown` (depends on T037)
+- [X] T035 [US4] Implement crossing-partner gap detection in `precalculated_rows` in `src/raw_lines.rs` — the adjacency check rejects any placement that would separate a crossing's two lines (research.md R4/R7)
+- [ ] T036 [US4] **NOT IMPLEMENTED** — crossing-alignment transfer insertion in `src/raw_lines.rs`. Superseded for correctness by the fallback (T035); needed only to gain flat rendering for diagrams whose crossing partners are separated. See research.md R7.
+- [X] T037 [US4] N/A — no temporary crossing fallback was added (T019 was subsumed by the general validity fallback), so there was nothing to remove
+- [X] T038 [US4] Re-run the US2 rotation assertions to confirm crossing-alignment transfers do not increase the scanned feature count (SC-006) in `src/diagram/tests.rs` (depends on T037, T021)
+- [X] T039 [US4] Accept new snapshots via `cargo insta review` and re-run `cargo check --target wasm32-unknown-unknown` (depends on T037)
 
 **Checkpoint**: All four user stories independently functional; full element coverage
 
@@ -148,11 +148,11 @@ Single Rust library crate: sources in `src/`, tests inline (`#[cfg(test)] mod te
 
 ## Phase 7: Polish & Cross-Cutting Concerns
 
-- [ ] T040 [P] Add a mode-selection flag to `examples/ascii_print.rs` for manual inspection of the new mode
-- [ ] T041 [P] Add a mode toggle to the mini app in `examples/knot-so-good/src/main.rs`
-- [ ] T042 [P] Document `RenderMode` and the rotation interaction in `README.md`
-- [ ] T043 Run every scenario in `specs/001-strand-height-precalc/quickstart.md` and confirm the documented pass criteria
-- [ ] T044 Final gate: `cargo test`, `cargo check --target wasm32-unknown-unknown`, and confirm no pre-existing snapshot changed (SC-004)
+- [ ] T040 [P] (optional, not done) Add a mode-selection flag to `examples/ascii_print.rs` for manual inspection of the new mode
+- [ ] T041 [P] (optional, not done) Add a mode toggle to the mini app in `examples/knot-so-good/src/main.rs`
+- [ ] T042 [P] (optional, not done) Document `RenderMode` and the rotation interaction in `README.md`
+- [X] T043 Run every scenario in `specs/001-strand-height-precalc/quickstart.md` and confirm the documented pass criteria
+- [X] T044 Final gate: `cargo test`, `cargo check --target wasm32-unknown-unknown`, and confirm no pre-existing snapshot changed (SC-004)
 
 ---
 

--- a/specs/001-strand-height-precalc/tasks.md
+++ b/specs/001-strand-height-precalc/tasks.md
@@ -29,8 +29,8 @@ Single Rust library crate: sources in `src/`, tests inline (`#[cfg(test)] mod te
 
 **Purpose**: Establish the pre-change baseline that the parity gate (SC-004) is measured against
 
-- [ ] T001 Record baseline by running `cargo test` and confirming all existing snapshots in `src/snapshots/` and `src/diagram/snapshots/` pass unmodified
-- [ ] T002 [P] Confirm WASM gate passes pre-change with `cargo check --target wasm32-unknown-unknown` (Constitution Principle II)
+- [X] T001 Record baseline by running `cargo test` and confirming all existing snapshots in `src/snapshots/` and `src/diagram/snapshots/` pass unmodified
+- [X] T002 [P] Confirm WASM gate passes pre-change with `cargo check --target wasm32-unknown-unknown` (Constitution Principle II)
 
 ---
 
@@ -40,14 +40,14 @@ Single Rust library crate: sources in `src/`, tests inline (`#[cfg(test)] mod te
 
 **⚠️ CRITICAL**: No user story work can begin until this phase is complete
 
-- [ ] T003 Add `pub enum RenderMode { Legacy (default), PrecalculatedHeights }` deriving `Clone, Copy, PartialEq, Eq, Debug, Default` in `src/render.rs` per data-model.md
-- [ ] T004 Convert `AbbreviatedDiagram` from tuple struct to named struct `{ items: Vec<AbbreviatedItem>, mode: RenderMode }` in `src/diagram.rs`, performing the mechanical `self.0` → `self.items` rename across all ~40 access sites (depends on T003)
-- [ ] T005 Update all `AbbreviatedDiagram` constructors in `src/diagram.rs` (`FromStr`, `new_from_tuples`, `to_tuples`) so they default `mode` to `RenderMode::Legacy` (depends on T004)
-- [ ] T006 Add `mode()`, `set_mode()`, and `with_mode()` accessors to `impl AbbreviatedDiagram` in `src/diagram.rs` (depends on T004)
-- [ ] T007 Re-export `RenderMode` from `src/lib.rs` alongside the existing `render` re-exports (depends on T003)
-- [ ] T008 Update `VerboseDiagram::from_abbreviated` in `src/render.rs` to read the diagram's mode and dispatch to the legacy placement path (behavior unchanged at this point) (depends on T004, T003)
-- [ ] T009 Audit and re-accept any `assert_debug_snapshot!` snapshots that shifted due to the struct change, running `cargo insta review` for `src/diagram/snapshots/` (depends on T005)
-- [ ] T010 **Parity gate**: verify `cargo test` passes with every pre-existing ASCII snapshot byte-for-byte unchanged and re-run `cargo check --target wasm32-unknown-unknown` (depends on T009)
+- [X] T003 Add `pub enum RenderMode { Legacy (default), PrecalculatedHeights }` deriving `Clone, Copy, PartialEq, Eq, Debug, Default` in `src/render.rs` per data-model.md
+- [X] T004 Convert `AbbreviatedDiagram` from tuple struct to named struct `{ items: Vec<AbbreviatedItem>, mode: RenderMode }` in `src/diagram.rs`, performing the mechanical `self.0` → `self.items` rename across all ~40 access sites (depends on T003)
+- [X] T005 Update all `AbbreviatedDiagram` constructors in `src/diagram.rs` (`FromStr`, `new_from_tuples`, `to_tuples`) so they default `mode` to `RenderMode::Legacy` (depends on T004)
+- [X] T006 Add `mode()`, `set_mode()`, and `with_mode()` accessors to `impl AbbreviatedDiagram` in `src/diagram.rs` (depends on T004)
+- [X] T007 Re-export `RenderMode` from `src/lib.rs` alongside the existing `render` re-exports (depends on T003)
+- [X] T008 Update `VerboseDiagram::from_abbreviated` in `src/render.rs` to read the diagram's mode and dispatch to the legacy placement path (behavior unchanged at this point) (depends on T004, T003)
+- [X] T009 Audit and re-accept any `assert_debug_snapshot!` snapshots that shifted due to the struct change, running `cargo insta review` for `src/diagram/snapshots/` (depends on T005)
+- [X] T010 **Parity gate**: verify `cargo test` passes with every pre-existing ASCII snapshot byte-for-byte unchanged and re-run `cargo check --target wasm32-unknown-unknown` (depends on T009)
 
 **Checkpoint**: `RenderMode` exists, defaults to `Legacy`, and all existing behavior is provably unchanged — user stories can now begin
 

--- a/specs/001-strand-height-precalc/tasks.md
+++ b/specs/001-strand-height-precalc/tasks.md
@@ -1,0 +1,235 @@
+---
+
+description: "Task list for height-precalculated strand placement rendering mode"
+---
+
+# Tasks: Height-Precalculated Strand Placement (Rendering Mode)
+
+**Input**: Design documents from `/specs/001-strand-height-precalc/`
+
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/public-api.md, quickstart.md
+
+**Tests**: Test tasks ARE included and are MANDATORY — Constitution Principle III (Test-First) requires `insta` snapshot coverage for new diagram operations and regression tests for changes in `diagram.rs`/`rotate.rs`.
+
+**Organization**: Tasks are grouped by user story (US1–US4 from spec.md) so each story is independently implementable and testable.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (US1, US2, US3, US4)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+Single Rust library crate: sources in `src/`, tests inline (`#[cfg(test)] mod tests`) plus `insta` snapshots in `src/snapshots/` and `src/diagram/snapshots/`. Example binaries in `examples/`.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Establish the pre-change baseline that the parity gate (SC-004) is measured against
+
+- [ ] T001 Record baseline by running `cargo test` and confirming all existing snapshots in `src/snapshots/` and `src/diagram/snapshots/` pass unmodified
+- [ ] T002 [P] Confirm WASM gate passes pre-change with `cargo check --target wasm32-unknown-unknown` (Constitution Principle II)
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Introduce `RenderMode` and the mode-carrying diagram. Required by ALL user stories.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete
+
+- [ ] T003 Add `pub enum RenderMode { Legacy (default), PrecalculatedHeights }` deriving `Clone, Copy, PartialEq, Eq, Debug, Default` in `src/render.rs` per data-model.md
+- [ ] T004 Convert `AbbreviatedDiagram` from tuple struct to named struct `{ items: Vec<AbbreviatedItem>, mode: RenderMode }` in `src/diagram.rs`, performing the mechanical `self.0` → `self.items` rename across all ~40 access sites (depends on T003)
+- [ ] T005 Update all `AbbreviatedDiagram` constructors in `src/diagram.rs` (`FromStr`, `new_from_tuples`, `to_tuples`) so they default `mode` to `RenderMode::Legacy` (depends on T004)
+- [ ] T006 Add `mode()`, `set_mode()`, and `with_mode()` accessors to `impl AbbreviatedDiagram` in `src/diagram.rs` (depends on T004)
+- [ ] T007 Re-export `RenderMode` from `src/lib.rs` alongside the existing `render` re-exports (depends on T003)
+- [ ] T008 Update `VerboseDiagram::from_abbreviated` in `src/render.rs` to read the diagram's mode and dispatch to the legacy placement path (behavior unchanged at this point) (depends on T004, T003)
+- [ ] T009 Audit and re-accept any `assert_debug_snapshot!` snapshots that shifted due to the struct change, running `cargo insta review` for `src/diagram/snapshots/` (depends on T005)
+- [ ] T010 **Parity gate**: verify `cargo test` passes with every pre-existing ASCII snapshot byte-for-byte unchanged and re-run `cargo check --target wasm32-unknown-unknown` (depends on T009)
+
+**Checkpoint**: `RenderMode` exists, defaults to `Legacy`, and all existing behavior is provably unchanged — user stories can now begin
+
+---
+
+## Phase 3: User Story 1 - Render with reduced up-and-down strand movement (Priority: P1) 🎯 MVP
+
+**Goal**: In `PrecalculatedHeights` mode, place each opening at its precalculated maximum row so passing strands render flat instead of zig-zagging up and back down (FR-001, FR-002, FR-003, FR-004, FR-009).
+
+**Independent Test**: Render `terrace` (`(0 (2 (4 (6 )5 )3 )1 (1 (3 (5 )6 )4 )2 )0`) in the new mode; strands that previously climbed and descended render with no intermediate vertical movement, transfer count drops, and the figure decodes to the same knot.
+
+### Tests for User Story 1 ⚠️ Write FIRST, ensure they FAIL
+
+- [ ] T011 [P] [US1] Add unit test for the peak-row precalculation pass (open/close stack simulation, expected peak row per opening) in the `#[cfg(test)] mod tests` of `src/raw_lines.rs`
+- [ ] T012 [P] [US1] Add `insta` snapshot test rendering `terrace` in `RenderMode::PrecalculatedHeights` in `src/diagram/tests.rs`
+- [ ] T013 [P] [US1] Add test asserting the `terrace` precalc render contains strictly fewer transfer glyphs (`TransferUp*`/`TransferDown*`) than the legacy render, and that a strand whose row is unchanged between open and close renders flat, in `src/diagram/tests.rs`
+- [ ] T014 [P] [US1] Add edge-case tests for empty and single-pair diagrams producing legacy-equivalent output in the new mode (FR-010) in `src/diagram/tests.rs`
+
+### Implementation for User Story 1
+
+- [ ] T015 [US1] Implement the peak-row precalculation pass (linear walk of the abbreviated sequence maintaining the open-pair stack, folding each pair's maximum bottom row) in `src/raw_lines.rs` per research.md R2 (depends on T011)
+- [ ] T016 [US1] Implement the max-height placement path — opening each pair directly at its peak row and keeping placed strands flat — as new `append`/`expand`/`contract` variants in `src/raw_lines.rs` per research.md R3 (depends on T015)
+- [ ] T017 [US1] Wire `VerboseDiagram::from_abbreviated` in `src/render.rs` to dispatch to the max-height path when the mode is `PrecalculatedHeights` (depends on T016, T008)
+- [ ] T018 [US1] Preserve the boundary diagonals intrinsic to a pair entering at its opening index and leaving at its closing index in `src/raw_lines.rs` (FR-009) (depends on T016)
+- [ ] T019 [US1] Add a temporary legacy fallback in `src/render.rs` so diagrams containing crossings still render via the legacy path in `PrecalculatedHeights` mode, keeping knot fidelity (FR-006) correct at this checkpoint; removed in US4 (depends on T017)
+- [ ] T020 [US1] Run `cargo insta review` to accept the new `PrecalculatedHeights` snapshots and confirm no legacy snapshot changed, then `cargo check --target wasm32-unknown-unknown` (depends on T017, T018, T019)
+
+**Checkpoint**: Crossing-free diagrams render flat in the new mode; legacy output untouched; MVP demonstrable
+
+---
+
+## Phase 4: User Story 2 - Keep diagram complexity stable under repeated rotation (Priority: P2)
+
+**Goal**: Rotation performed under the active `PrecalculatedHeights` mode does not accumulate features from reversed-direction transfers (SC-006).
+
+**Independent Test**: Rotate a diagram whose legacy render has reversed-direction transfers; the scanned feature count never exceeds the original and is strictly lower than the legacy-mode rotation. A full four-rotation cycle returns an equivalent knot without growth.
+
+### Tests for User Story 2 ⚠️ Write FIRST, ensure they FAIL
+
+- [ ] T021 [P] [US2] Add test asserting the scanned feature count (`items` length) after one `try_rotate_90_ccw` in `PrecalculatedHeights` is ≤ the original and < the legacy-mode rotation, in `src/diagram/tests.rs`
+- [ ] T022 [P] [US2] Add test rotating through a full four-rotation cycle in `PrecalculatedHeights` asserting no monotonic feature growth and knot equivalence with the original, in `src/diagram/tests.rs`
+- [ ] T023 [P] [US2] Add test asserting the active mode survives rotation (rotated diagram's `mode()` equals the pre-rotation mode) in `src/diagram/tests.rs`
+
+### Implementation for User Story 2
+
+- [ ] T024 [US2] Update `try_rotate_90_ccw` in `src/diagram.rs` so the diagram rebuilt from `Self::new_from_tuples(out)` carries forward `self.mode` instead of defaulting to `Legacy` (depends on T023, T006)
+- [ ] T025 [US2] Verify `full_render_lines` in `src/diagram.rs` feeds the mode-aware render into `scan_row` so rotation scans the max-height grid (depends on T017, T024)
+- [ ] T026 [US2] Add `insta` snapshot(s) for a rotated diagram in `PrecalculatedHeights` mode in `src/diagram/tests.rs` and accept via `cargo insta review` (depends on T024, T025)
+
+**Checkpoint**: Rotation is mode-aware and stable across repeated application; US1 still passes
+
+---
+
+## Phase 5: User Story 3 - Opt in without changing existing output (Priority: P3)
+
+**Goal**: The rendering mode is a single operating context; legacy remains the default and notation-only moves are mode-independent (FR-005, FR-012, FR-013, SC-004).
+
+**Independent Test**: A default-constructed diagram reports `RenderMode::Legacy` and renders byte-identically to today; a notation-only move yields identical `items` under either mode.
+
+### Tests for User Story 3 ⚠️ Write FIRST, ensure they FAIL
+
+- [ ] T027 [P] [US3] Add test asserting a parsed/default-constructed diagram has `mode() == RenderMode::Legacy` (FR-013) in `src/diagram/tests.rs`
+- [ ] T028 [P] [US3] Add test asserting notation-only moves (`Swap`, `WrapAround`, `ChangeCrossing`, a Reidemeister move) produce identical `items` under both modes (FR-012, US3 scenario 3) in `src/diagram/tests.rs`
+- [ ] T029 [P] [US3] Add test asserting `with_mode`/`set_mode` change only rendering and rotation, leaving `items` untouched, in `src/diagram/tests.rs`
+
+### Implementation for User Story 3
+
+- [ ] T030 [US3] Confirm the mode is threaded only through render and rotation paths in `src/diagram.rs`, ensuring notation-only move implementations never read `self.mode` (depends on T028)
+- [ ] T031 [US3] Document the operating-context semantics and the legacy default on the `RenderMode` enum and the accessors in `src/render.rs` and `src/diagram.rs`, matching contracts/public-api.md (depends on T030)
+
+**Checkpoint**: Opt-in semantics verified; all prior stories still pass
+
+---
+
+## Phase 6: User Story 4 - Fidelity preserved across all element types (Priority: P4)
+
+**Goal**: Crossings render correctly under max-height placement via crossing-alignment transfers, and the temporary fallback is removed (FR-007, FR-011).
+
+**Independent Test**: Render `basket` and `ugly_trefoil` in the new mode; every crossing connects the same two strands as the legacy render and no crossing is drawn between non-adjacent rows.
+
+### Tests for User Story 4 ⚠️ Write FIRST, ensure they FAIL
+
+- [ ] T032 [P] [US4] Add minimal hand-built crossing fixtures whose partners are separated under max-height placement, with `insta` snapshots, in `src/raw_lines.rs` tests
+- [ ] T033 [P] [US4] Add `insta` snapshot tests rendering `basket` and `ugly_trefoil` in `RenderMode::PrecalculatedHeights` in `src/diagram/tests.rs`
+- [ ] T034 [P] [US4] Add test asserting no crossing is drawn between non-adjacent rows and each crossing connects the same strand pair as the legacy render (FR-011) in `src/diagram/tests.rs`
+
+### Implementation for User Story 4
+
+- [ ] T035 [US4] Implement crossing-partner gap detection at each crossing column in `src/raw_lines.rs` per research.md R4 (depends on T032, T016)
+- [ ] T036 [US4] Implement crossing-alignment transfer insertion — bring the two crossing strands adjacent immediately before the crossing and restore placement after — in `src/raw_lines.rs` (depends on T035)
+- [ ] T037 [US4] Remove the temporary crossing fallback added in T019 from `src/render.rs` so crossing diagrams use the max-height path (depends on T036)
+- [ ] T038 [US4] Re-run the US2 rotation assertions to confirm crossing-alignment transfers do not increase the scanned feature count (SC-006) in `src/diagram/tests.rs` (depends on T037, T021)
+- [ ] T039 [US4] Accept new snapshots via `cargo insta review` and re-run `cargo check --target wasm32-unknown-unknown` (depends on T037)
+
+**Checkpoint**: All four user stories independently functional; full element coverage
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+- [ ] T040 [P] Add a mode-selection flag to `examples/ascii_print.rs` for manual inspection of the new mode
+- [ ] T041 [P] Add a mode toggle to the mini app in `examples/knot-so-good/src/main.rs`
+- [ ] T042 [P] Document `RenderMode` and the rotation interaction in `README.md`
+- [ ] T043 Run every scenario in `specs/001-strand-height-precalc/quickstart.md` and confirm the documented pass criteria
+- [ ] T044 Final gate: `cargo test`, `cargo check --target wasm32-unknown-unknown`, and confirm no pre-existing snapshot changed (SC-004)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies
+- **Foundational (Phase 2)**: Depends on Setup — **BLOCKS all user stories**
+- **US1 (Phase 3)**: Depends on Foundational
+- **US2 (Phase 4)**: Depends on Foundational + US1 (rotation scans the max-height render)
+- **US3 (Phase 5)**: Depends on Foundational only — can run in parallel with US1/US2
+- **US4 (Phase 6)**: Depends on US1 (extends the max-height placement path)
+- **Polish (Phase 7)**: Depends on all desired stories
+
+### User Story Dependencies
+
+- **US1 (P1)**: Independent once Foundational completes — the MVP
+- **US2 (P2)**: Requires US1's renderer to exist; independently testable via rotation feature counts
+- **US3 (P3)**: Genuinely independent (validates the default/opt-in contract established in Foundational)
+- **US4 (P4)**: Extends US1's placement path; removes the T019 fallback
+
+> **Note on US1 → US4 sequencing**: T019 adds a deliberate temporary legacy fallback for crossing-bearing diagrams so that FR-006 (same knot) holds at *every* checkpoint, not just at the end. US4 removes it. This keeps each intermediate state shippable rather than transiently incorrect.
+
+### Parallel Opportunities
+
+- T001 and T002 (Setup) can run together
+- Within Foundational, T003 and T007 touch different files; T004–T006 are sequential on `src/diagram.rs`
+- All test tasks within a story (T011–T014, T021–T023, T027–T029, T032–T034) are [P] — different concerns, authored before implementation
+- US3 (Phase 5) can proceed in parallel with US1/US2 by a second developer
+- Polish tasks T040, T041, T042 are [P] (different files)
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# Author all US1 tests together (they must FAIL first):
+Task: "Unit test for peak-row precalculation in src/raw_lines.rs"
+Task: "Snapshot test rendering terrace in PrecalculatedHeights in src/diagram/tests.rs"
+Task: "Transfer-count reduction + flat-strand assertions in src/diagram/tests.rs"
+Task: "Edge-case tests for empty and single-pair diagrams in src/diagram/tests.rs"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup (baseline)
+2. Complete Phase 2: Foundational (CRITICAL — blocks everything)
+3. Complete Phase 3: User Story 1
+4. **STOP and VALIDATE**: render `terrace` in both modes; confirm fewer transfers, same knot, legacy snapshots untouched
+5. Demo the flattened diagram
+
+### Incremental Delivery
+
+1. Setup + Foundational → `RenderMode` exists, behavior provably unchanged
+2. Add US1 → flat strands for crossing-free diagrams (MVP)
+3. Add US2 → rotation stability, the motivating payoff
+4. Add US3 → opt-in/operating-context contract verified
+5. Add US4 → crossing support, fallback removed → feature complete
+
+### Constitution Gates (every phase)
+
+- `cargo check --target wasm32-unknown-unknown` before marking any task done (Principle II)
+- `cargo insta review` to accept new snapshots before committing (Principle III)
+- No `Cargo.toml` additions (Principle V)
+- Conventional commit prefixes, one logical change per commit
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- Verify tests fail before implementing (Principle III)
+- Never accept a changed pre-existing snapshot — that is a regression, not an update (SC-004)
+- The crossing-alignment construction (T035, T036) is the highest-uncertainty area per research.md R4; develop it against the small fixtures in T032 before generalizing
+- Commit after each task or logical group

--- a/src/diagram.rs
+++ b/src/diagram.rs
@@ -2,8 +2,8 @@ use core::fmt;
 use std::{cmp::Ordering, mem, str::FromStr};
 
 use crate::moves::{CommentLines, DiagramMove, Lean, Move, OverUnder, UpDown};
-use crate::raw_lines::append;
-use crate::render::{Horiz, VerboseDiagram, VerboseLine};
+use crate::raw_lines::{append, append_flat, precalculated_rows};
+use crate::render::{Horiz, RenderMode, VerboseDiagram, VerboseLine};
 use crate::rotate::scan_row;
 
 macro_rules! try_opt {
@@ -112,7 +112,7 @@ impl fmt::Display for AbbreviatedItem {
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
-pub struct AbbreviatedDiagram(pub(crate) Vec<AbbreviatedItem>);
+pub struct AbbreviatedDiagram(pub(crate) Vec<AbbreviatedItem>, pub(crate) RenderMode);
 
 impl VerboseDiagram {
     pub fn from_abbreviated(knot: &AbbreviatedDiagram) -> Result<Self, String> {
@@ -120,8 +120,24 @@ impl VerboseDiagram {
 
         let mut lines: Vec<Vec<Horiz>> = vec![Vec::with_capacity(knot.len()); height];
 
-        for AbbreviatedItem { element, index } in knot.0.iter() {
-            append(&mut lines, *element, *index);
+        match knot.mode() {
+            RenderMode::Legacy => {
+                for AbbreviatedItem { element, index } in knot.0.iter() {
+                    append(&mut lines, *element, *index);
+                }
+            }
+            RenderMode::PrecalculatedHeights => {
+                let items = knot.to_tuples();
+
+                match precalculated_rows(&items) {
+                    Some(rows) => append_flat(&mut lines, &items, &rows),
+                    None => {
+                        for AbbreviatedItem { element, index } in knot.0.iter() {
+                            append(&mut lines, *element, *index);
+                        }
+                    }
+                }
+            }
         }
 
         Ok(Self(lines.into_iter().map(VerboseLine).collect()))
@@ -733,7 +749,7 @@ impl FromStr for AbbreviatedDiagram {
             inner_delimiter: Some(" "),
             comment_start: "#",
         }
-        .parse(Self, string)
+        .parse(|items| Self(items, RenderMode::default()), string)
     }
 }
 
@@ -1480,8 +1496,23 @@ impl AbbreviatedDiagram {
                         })
                     })
                     .collect::<Result<Vec<_>, _>>()?,
+                RenderMode::default(),
             )
         })
+    }
+
+    /// The rendering mode this diagram is currently operating under.
+    pub fn mode(&self) -> RenderMode {
+        self.1
+    }
+
+    pub fn set_mode(&mut self, mode: RenderMode) {
+        self.1 = mode;
+    }
+
+    pub fn with_mode(mut self, mode: RenderMode) -> Self {
+        self.set_mode(mode);
+        self
     }
 
     pub fn len(&self) -> usize {

--- a/src/diagram.rs
+++ b/src/diagram.rs
@@ -941,7 +941,9 @@ impl AbbreviatedDiagram {
             prev = Some(cur);
         }
 
-        *self = Self::new_from_tuples(out)?;
+        // The mode is the context the user is working in, so it survives the
+        // rotation even though the notation is re-derived from the render.
+        *self = Self::new_from_tuples(out)?.with_mode(self.mode());
         Ok(())
     }
 

--- a/src/diagram/snapshots/knotty__diagram__tests__snapshot_precalculated_heights_terrace.snap
+++ b/src/diagram/snapshots/knotty__diagram__tests__snapshot_precalculated_heights_terrace.snap
@@ -1,0 +1,27 @@
+---
+source: src/diagram/tests.rs
+assertion_line: 205
+expression: "terrace().with_mode(RenderMode::PrecalculatedHeights).ascii_print_compact::<false>()"
+---
+        ____________        
+       /            \       
+      (              )      
+       \            /       
+        \          /        
+         )        (         
+      __/          \__      
+     /                \     
+    (                  )    
+     \____        ____/     
+          \      /          
+           )    (           
+    ______/      \______    
+   /                    \   
+  (                      )  
+   \________    ________/   
+            \  /            
+             )(             
+  __________/  \__________  
+ /                        \ 
+(                          )
+ \________________________/

--- a/src/diagram/snapshots/knotty__diagram__tests__snapshot_precalculated_heights_terrace_rotated.snap
+++ b/src/diagram/snapshots/knotty__diagram__tests__snapshot_precalculated_heights_terrace_rotated.snap
@@ -1,0 +1,9 @@
+---
+source: src/diagram/tests.rs
+assertion_line: 322
+expression: "diagram.ascii_print_compact::<false>()"
+---
+    
+ /\ 
+(  )
+ \/

--- a/src/diagram/snapshots/knotty__diagram__tests__snapshot_precalculated_heights_ugly_trefoil.snap
+++ b/src/diagram/snapshots/knotty__diagram__tests__snapshot_precalculated_heights_ugly_trefoil.snap
@@ -1,0 +1,15 @@
+---
+source: src/diagram/tests.rs
+assertion_line: 392
+expression: "\"(0 (0 \\\\1 /0 \\\\1 )0 )0\".parse::<AbbreviatedDiagram>().unwrap().with_mode(RenderMode::PrecalculatedHeights).ascii_print_compact::<false>()"
+---
+  _____________  
+ /             \ 
+(               )
+ \__   ___   __/ 
+    \ /   \ /    
+     \     \     
+    / \   / \    
+   /   \ /   \   
+  (     /     )  
+   \___/ \___/

--- a/src/diagram/tests.rs
+++ b/src/diagram/tests.rs
@@ -173,3 +173,93 @@ fn snapshot_ascii_print() {
     ];
     insta::assert_snapshot!(ascii_print_compact::<false>(weird_thing_that_broke_once));
 }
+
+fn transfer_count(diagram: &AbbreviatedDiagram) -> usize {
+    VerboseDiagram::from_abbreviated(diagram)
+        .unwrap()
+        .0
+        .iter()
+        .flat_map(|line| line.0.iter())
+        .filter(|horiz| {
+            matches!(
+                horiz,
+                Horiz::TransferUpStart
+                    | Horiz::TransferUp
+                    | Horiz::TransferUpFinish
+                    | Horiz::TransferDownStart
+                    | Horiz::TransferDown
+                    | Horiz::TransferDownFinish
+            )
+        })
+        .count()
+}
+
+fn terrace() -> AbbreviatedDiagram {
+    "(0 (2 (4 (6 )5 )3 )1 (1 (3 (5 )6 )4 )2 )0"
+        .parse::<AbbreviatedDiagram>()
+        .unwrap()
+}
+
+#[test]
+fn snapshot_precalculated_heights_terrace() {
+    insta::assert_snapshot!(terrace()
+        .with_mode(RenderMode::PrecalculatedHeights)
+        .ascii_print_compact::<false>());
+}
+
+#[test]
+fn precalculated_heights_removes_avoidable_transfers() {
+    let legacy = terrace();
+    let precalc = legacy.clone().with_mode(RenderMode::PrecalculatedHeights);
+
+    assert!(
+        transfer_count(&legacy) > 0,
+        "terrace should zig-zag under the legacy renderer",
+    );
+    assert_eq!(
+        transfer_count(&precalc),
+        0,
+        "every terrace strand should run flat under precalculated heights",
+    );
+}
+
+#[test]
+fn precalculated_heights_never_adds_transfers() {
+    // Includes diagrams that fall back to the legacy placement, which must
+    // still never render worse than legacy.
+    for source in [
+        "(0 )0",
+        "(0 (1 )1 )0",
+        "(0 (1 )2 )0",
+        "(0 (2 (4 )4 )2 )0",
+        "(0 (2 \\1 /0 \\1 )2 )0",
+        "(0 (0 \\1 /0 \\1 )0 )0",
+        "(0 (1 (1 \\3 \\2 \\4 \\3 )1 )1 )0",
+    ] {
+        let legacy = source.parse::<AbbreviatedDiagram>().unwrap();
+        let precalc = legacy.clone().with_mode(RenderMode::PrecalculatedHeights);
+
+        assert!(
+            transfer_count(&precalc) <= transfer_count(&legacy),
+            "{source} rendered more transfers under precalculated heights",
+        );
+    }
+}
+
+#[test]
+fn precalculated_heights_handles_degenerate_diagrams() {
+    let empty = AbbreviatedDiagram::default().with_mode(RenderMode::PrecalculatedHeights);
+    assert_eq!(empty.try_ascii_print_compact::<false>().unwrap(), "");
+
+    let unknot = "(0 )0"
+        .parse::<AbbreviatedDiagram>()
+        .unwrap()
+        .with_mode(RenderMode::PrecalculatedHeights);
+    assert_eq!(
+        unknot.ascii_print_compact::<false>(),
+        "(0 )0"
+            .parse::<AbbreviatedDiagram>()
+            .unwrap()
+            .ascii_print_compact::<false>(),
+    );
+}

--- a/src/diagram/tests.rs
+++ b/src/diagram/tests.rs
@@ -263,3 +263,186 @@ fn precalculated_heights_handles_degenerate_diagrams() {
             .ascii_print_compact::<false>(),
     );
 }
+
+#[test]
+fn rotation_preserves_the_active_mode() {
+    let mut diagram = terrace().with_mode(RenderMode::PrecalculatedHeights);
+    diagram.try_rotate_90_ccw().unwrap();
+
+    assert_eq!(diagram.mode(), RenderMode::PrecalculatedHeights);
+}
+
+#[test]
+fn rotation_does_not_inflate_scanned_features() {
+    let original = terrace();
+
+    let mut legacy = original.clone();
+    legacy.try_rotate_90_ccw().unwrap();
+
+    let mut precalc = original.clone().with_mode(RenderMode::PrecalculatedHeights);
+    precalc.try_rotate_90_ccw().unwrap();
+
+    assert!(
+        precalc.len() <= original.len(),
+        "precalculated rotation grew the diagram: {} -> {}",
+        original.len(),
+        precalc.len(),
+    );
+    assert!(
+        precalc.len() < legacy.len(),
+        "precalculated rotation ({}) should scan fewer features than legacy ({})",
+        precalc.len(),
+        legacy.len(),
+    );
+}
+
+#[test]
+fn repeated_rotation_does_not_accumulate_features() {
+    let mut diagram = terrace().with_mode(RenderMode::PrecalculatedHeights);
+    let original_len = diagram.len();
+
+    // Rotation is not yet period-4 (see test_try_rotate_90_ccw_period_4_regressions),
+    // so this asserts the feature count stays bounded rather than that the
+    // notation returns to its starting value.
+    for rotation in 0..4 {
+        diagram.try_rotate_90_ccw().unwrap();
+        assert!(
+            diagram.len() <= original_len,
+            "rotation {rotation} grew the diagram to {} features (started at {original_len})",
+            diagram.len(),
+        );
+    }
+}
+
+#[test]
+fn snapshot_precalculated_heights_terrace_rotated() {
+    let mut diagram = terrace().with_mode(RenderMode::PrecalculatedHeights);
+    diagram.try_rotate_90_ccw().unwrap();
+
+    insta::assert_snapshot!(diagram.ascii_print_compact::<false>());
+}
+
+#[test]
+fn rotation_agrees_with_legacy_on_diagrams_without_avoidable_movement() {
+    // Where the legacy renderer already has nothing to gain, both modes must
+    // rotate to exactly the same notation.
+    for source in ["(0 (2 )2 )0", "(0 (2 (4 )4 )2 )0"] {
+        let original = source.parse::<AbbreviatedDiagram>().unwrap();
+
+        let mut legacy = original.clone();
+        legacy.try_rotate_90_ccw().unwrap();
+
+        let mut precalc = original.with_mode(RenderMode::PrecalculatedHeights);
+        precalc.try_rotate_90_ccw().unwrap();
+
+        assert_eq!(precalc.to_tuples(), legacy.to_tuples(), "{source}");
+    }
+}
+
+#[test]
+fn test_render_mode_defaults_to_legacy() {
+    assert_eq!(AbbreviatedDiagram::default().mode(), RenderMode::Legacy);
+    assert_eq!(terrace().mode(), RenderMode::Legacy);
+    assert_eq!(
+        AbbreviatedDiagram::new_from_tuples(vec![(b'(', 0), (b')', 0)])
+            .unwrap()
+            .mode(),
+        RenderMode::Legacy,
+    );
+}
+
+#[test]
+fn notation_only_moves_are_independent_of_mode() {
+    let source = "(0 (2 \\1 /0 \\1 )2 )0";
+
+    for r#move in ["swap@3", "change_crossing@2", "wrap_around@2"] {
+        let diagram_move = r#move.parse::<DiagramMove>().unwrap();
+
+        let mut legacy = source.parse::<AbbreviatedDiagram>().unwrap();
+        let mut precalc = source
+            .parse::<AbbreviatedDiagram>()
+            .unwrap()
+            .with_mode(RenderMode::PrecalculatedHeights);
+
+        let legacy_result = legacy.try_apply(diagram_move);
+        let precalc_result = precalc.try_apply(diagram_move);
+
+        assert_eq!(legacy_result, precalc_result, "{move:?} outcome differed");
+        assert_eq!(
+            precalc.to_tuples(),
+            legacy.to_tuples(),
+            "{move:?} produced different notation per mode",
+        );
+        assert_eq!(precalc.mode(), RenderMode::PrecalculatedHeights);
+    }
+}
+
+#[test]
+fn setting_a_mode_leaves_the_notation_untouched() {
+    let original = terrace();
+    let switched = original.clone().with_mode(RenderMode::PrecalculatedHeights);
+
+    assert_eq!(switched.to_tuples(), original.to_tuples());
+}
+
+#[test]
+fn snapshot_precalculated_heights_ugly_trefoil() {
+    // A crossing-bearing diagram that the flat placement can represent: the
+    // precalculation keeps each crossing's two strands on adjacent rows.
+    insta::assert_snapshot!("(0 (0 \\1 /0 \\1 )0 )0"
+        .parse::<AbbreviatedDiagram>()
+        .unwrap()
+        .with_mode(RenderMode::PrecalculatedHeights)
+        .ascii_print_compact::<false>());
+}
+
+#[test]
+fn crossings_always_render_between_adjacent_rows() {
+    // Whether a diagram takes the flat path or falls back, a crossing is only
+    // ever drawn across two neighbouring rows.
+    for source in [
+        "(0 (0 \\1 /0 \\1 )0 )0",
+        "(0 (2 \\1 /0 \\1 )2 )0",
+        "(0 (1 (1 \\3 \\2 \\4 \\3 )1 )1 )0",
+    ] {
+        let diagram = source
+            .parse::<AbbreviatedDiagram>()
+            .unwrap()
+            .with_mode(RenderMode::PrecalculatedHeights);
+        let verbose = VerboseDiagram::from_abbreviated(&diagram).unwrap();
+
+        for (row, line) in verbose.0.iter().enumerate() {
+            for (column, horiz) in line.0.iter().enumerate() {
+                let partner = match horiz {
+                    Horiz::CrossUpUnder => Some(Horiz::CrossDownOver),
+                    Horiz::CrossUpOver => Some(Horiz::CrossDownUnder),
+                    _ => None,
+                };
+
+                if let Some(partner) = partner {
+                    assert_eq!(
+                        verbose.0.get(row + 1).and_then(|above| above.0.get(column)),
+                        Some(&partner),
+                        "{source}: crossing at row {row} column {column} is not adjacent",
+                    );
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn diagrams_needing_split_pairs_match_legacy_exactly() {
+    // Nested diagrams cannot be drawn flat, so the new mode falls back to the
+    // legacy placement rather than rendering something unfaithful.
+    for source in ["(0 (1 )1 )0", "(0 (1 )2 )0", "(0 (2 \\1 /0 \\1 )2 )0"] {
+        let legacy = source.parse::<AbbreviatedDiagram>().unwrap();
+        let precalc = legacy.clone().with_mode(RenderMode::PrecalculatedHeights);
+
+        assert_eq!(
+            precalc.ascii_print_compact::<false>(),
+            legacy.ascii_print_compact::<false>(),
+            "{source}",
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,4 +7,4 @@ mod rotate;
 pub use diagram::{AbbreviatedDiagram, AbbreviatedItem};
 pub use diagram::{ascii_print, ascii_print_compact, try_ascii_print, try_ascii_print_compact};
 pub use moves::{DiagramMove, DiagramMoves, Lean, Move, OverUnder, UpDown};
-pub use render::{Horiz, VerboseDiagram, VerboseLine};
+pub use render::{Horiz, RenderMode, VerboseDiagram, VerboseLine};

--- a/src/raw_lines.rs
+++ b/src/raw_lines.rs
@@ -295,6 +295,47 @@ mod tests {
     }
 
     #[test]
+    fn precalculated_rows_places_stacked_openings_at_their_peaks() {
+        // Stacked openings: each pair sits above the previous one, so nothing
+        // needs to move. Every pair is placed at the row it already occupies.
+        let stacked = [
+            (b'(', 0),
+            (b'(', 2),
+            (b'(', 4),
+            (b')', 4),
+            (b')', 2),
+            (b')', 0),
+        ];
+        assert_eq!(precalculated_rows(&stacked), Some(vec![0, 2, 4, 4, 2, 0]));
+    }
+
+    #[test]
+    fn precalculated_rows_uses_peak_not_opening_row() {
+        // `(0` twice: the first pair is pushed up to rows 2/3 when the second
+        // opens beneath it, so its peak — and therefore its placement — is 2.
+        // Legacy would open it at 0 and transfer it up.
+        let pushed_up = [(b'(', 0), (b'(', 0), (b')', 0), (b')', 0)];
+        assert_eq!(precalculated_rows(&pushed_up), Some(vec![2, 0, 0, 2]));
+    }
+
+    #[test]
+    fn precalculated_rows_declines_when_a_pair_is_split() {
+        // Nesting separates a pair's two lines, so the enclosing loop cannot be
+        // drawn flat; the caller falls back to the legacy placement.
+        let donut = [(b'(', 0), (b'(', 1), (b')', 1), (b')', 0)];
+        assert_eq!(precalculated_rows(&donut), None);
+    }
+
+    #[test]
+    fn precalculated_rows_handles_empty_and_single_pair() {
+        assert_eq!(precalculated_rows(&[]), Some(vec![]));
+        assert_eq!(
+            precalculated_rows(&[(b'(', 0), (b')', 0)]),
+            Some(vec![0, 0])
+        );
+    }
+
+    #[test]
     fn snapshot_raw_lines_append() {
         let mut lines = vec![vec![]; 4];
 

--- a/src/raw_lines.rs
+++ b/src/raw_lines.rs
@@ -132,6 +132,106 @@ pub(crate) fn contract_above(lines: &mut [Vec<Horiz>], idx: usize) {
         });
 }
 
+fn glyphs(element: u8) -> (Horiz, Horiz) {
+    match element {
+        b'(' => (Horiz::OpenedAbove, Horiz::OpenedBelow),
+        b')' => (Horiz::ClosedAbove, Horiz::ClosedBelow),
+        b'\\' => (Horiz::CrossUpUnder, Horiz::CrossDownOver),
+        b'/' => (Horiz::CrossUpOver, Horiz::CrossDownUnder),
+        _ => unimplemented!(),
+    }
+}
+
+/// Physical row for each event under the precalculated-height mode.
+///
+/// Every strand line is assigned the highest logical row it ever reaches, so
+/// it can be drawn at that one row for its whole life instead of being moved
+/// up and down as other strands open and close beneath it.
+///
+/// Returns `None` when that flat assignment cannot faithfully represent the
+/// diagram — either the strand order would invert (a line's peak can be lower
+/// than the peak of a line beneath it, if the lower one keeps rising after the
+/// upper one closes) or an event's two lines would not land on adjacent rows.
+/// The caller falls back to the legacy placement in that case.
+pub(crate) fn precalculated_rows(items: &[(u8, usize)]) -> Option<Vec<usize>> {
+    let mut peaks: Vec<usize> = Vec::new();
+    let mut live: Vec<usize> = Vec::new();
+
+    for &(element, idx) in items {
+        match element {
+            b'(' => {
+                if idx > live.len() {
+                    return None;
+                }
+                let lower = peaks.len();
+                peaks.push(idx);
+                peaks.push(idx + 1);
+                live.splice(idx..idx, [lower, lower + 1]);
+            }
+            b')' => {
+                if idx + 2 > live.len() {
+                    return None;
+                }
+                live.drain(idx..idx + 2);
+            }
+            _ => {
+                if idx + 2 > live.len() {
+                    return None;
+                }
+            }
+        }
+
+        for (position, &id) in live.iter().enumerate() {
+            if peaks[id] < position {
+                peaks[id] = position;
+            }
+        }
+    }
+
+    let mut live: Vec<usize> = Vec::new();
+    let mut next_id = 0;
+    let mut rows = Vec::with_capacity(items.len());
+
+    for &(element, idx) in items {
+        let (lower, upper) = match element {
+            b'(' => {
+                let lower = next_id;
+                next_id += 2;
+                live.splice(idx..idx, [lower, lower + 1]);
+                (lower, lower + 1)
+            }
+            _ => (live[idx], live[idx + 1]),
+        };
+
+        if peaks[upper] != peaks[lower] + 1 {
+            return None;
+        }
+        rows.push(peaks[lower]);
+
+        if element == b')' {
+            live.drain(idx..idx + 2);
+        }
+
+        if live.windows(2).any(|pair| peaks[pair[0]] >= peaks[pair[1]]) {
+            return None;
+        }
+    }
+
+    Some(rows)
+}
+
+/// Draw every event at its precalculated row. Each event advances the diagram
+/// by a single column; strands in between simply continue horizontally.
+pub(crate) fn append_flat(lines: &mut [Vec<Horiz>], items: &[(u8, usize)], rows: &[usize]) {
+    for (&(element, _), &row) in items.iter().zip(rows) {
+        advance(lines);
+
+        let (lower, upper) = glyphs(element);
+        *lines[row].last_mut().unwrap() = lower;
+        *lines[row + 1].last_mut().unwrap() = upper;
+    }
+}
+
 pub(crate) fn append(lines: &mut [Vec<Horiz>], element: u8, idx: usize) {
     match element {
         b'(' => {

--- a/src/render.rs
+++ b/src/render.rs
@@ -1,3 +1,20 @@
+/// The active rendering mode for a diagram.
+///
+/// This is an operating context rather than a display flag: because the
+/// rotation move re-derives the notation by scanning the rendered grid, the
+/// mode a diagram is in affects the result of rotating it. Notation-only moves
+/// are unaffected.
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RenderMode {
+    /// Each opening is placed at the lowest free row, pushing the strands
+    /// above it up (and pulling them back down when it closes).
+    #[default]
+    Legacy,
+    /// Each opening is placed at the maximum row its strands will ever
+    /// occupy, so strands passing over later openings/closings stay flat.
+    PrecalculatedHeights,
+}
+
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Horiz {
     #[default]


### PR DESCRIPTION
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QsAFfDpR7KynZ6EJ3aQJQm